### PR TITLE
Fix parseInt in map

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,9 @@ var callingCodesAll = _.reduce(countriesAll, function (codes, country) {
 }, []);
 
 callingCodesAll.sort(function (a, b) {
-  var splitA = _.map(a.split(' '), parseInt)
-  var splitB = _.map(b.split(' '), parseInt)
+  var parse = function (str) { return parseInt(str) };
+  var splitA = _.map(a.split(' '), parse);
+  var splitB = _.map(b.split(' '), parse);
 
   if (splitA[0] < splitB[0]) {
     return -1;


### PR DESCRIPTION
Apologies, I just realised that the `parseInt` wasn't working properly because the array index was being passed as the radix param! This should fix the ordering.
