### PR TITLE
Changing Latvian currency from LVL to EUR

### DIFF
--- a/data/countries.csv
+++ b/data/countries.csv
@@ -139,7 +139,7 @@ Liberia,LR,+231,LBR,LBR,LRD,eng,,assigned
 Lesotho,LS,+266,LSO,LES,"LSL,ZAR","eng,sot",,assigned
 Lithuania,LT,+370,LTU,LTU,LTL,lit,,assigned
 Luxembourg,LU,+352,LUX,LUX,EUR,"fre,ger,ltz",,assigned
-Latvia,LV,+371,LVA,LAT,LVL,lav,,assigned
+Latvia,LV,+371,LVA,LAT,EUR,lav,,assigned
 Libya,LY,+218,LBY,LBA,LYD,ara,,assigned
 Morocco,MA,+212,MAR,MAR,MAD,ara,,assigned
 Monaco,MC,+377,MCO,MON,EUR,fre,,assigned

--- a/data/countries.json
+++ b/data/countries.json
@@ -2256,7 +2256,7 @@
       "+371"
     ],
     "currencies": [
-      "LVL"
+      "EUR"
     ],
     "ioc": "LAT",
     "languages": [

--- a/test/countries.js
+++ b/test/countries.js
@@ -38,6 +38,12 @@ describe('countries', function () {
     });
   });
 
+  describe('check specific country currencies', function () {
+    it('Latvian currency should be EUR', function () {
+      assert.deepEqual( countries.LV.currencies, ['EUR']);
+    });
+  });
+
   describe('check languages for each country', function () {
     _.each( countries.all, function (country) {
       describe(country.alpha2, function () {


### PR DESCRIPTION
Latvia switched to Euro from 2014-01-01. See http://en.wikipedia.org/wiki/Latvian_euro_coins
