### PR TITLE
change United Kingdom to Olympic Great Britain

### DIFF
--- a/data/countries.json
+++ b/data/countries.json
@@ -1343,7 +1343,7 @@
       "gla",
       "cym"
     ],
-    "name": "United Kingdom",
+    "name": "Great Britain",
     "status": "assigned"
   },
   {


### PR DESCRIPTION
change to Great Britain like http://www.olympic.org/great-britain