### PR TITLE
Typo on Côte d'Ivoire

### DIFF
--- a/data/countries.csv
+++ b/data/countries.csv
@@ -54,12 +54,12 @@ Colombia,CO,COL,,+57,"COP,COU",COL,spa,assigned
 Comoros,KM,COM,,+269,KMF,COM,"ara,fra",assigned
 Cook Islands,CK,COK,,+682,NZD,COK,"eng,mri",assigned
 Costa Rica,CR,CRI,,+506,CRC,CRC,spa,assigned
-Cote d'Ivoire,CI,CIV,,+225,XOF,CIV,fra,assigned
 Croatia,HR,HRV,,+385,HRK,CRO,hrv,assigned
 Cuba,CU,CUB,,+53,"CUP,CUC",CUB,spa,assigned
 Curacao,CW,CUW,,+599,ANG,,nld,assigned
 Cyprus,CY,CYP,,+357,EUR,CYP,"ell,tur",assigned
 Czech Republic,CZ,CZE,,+420,CZK,CZE,ces,assigned
+Côte d'Ivoire,CI,CIV,,+225,XOF,CIV,fra,assigned
 Democratic Republic Of Congo,CD,COD,,+243,CDF,COD,"fra,lin,kon,swa",assigned
 Denmark,DK,DNK,,+45,DKK,DEN,dan,assigned
 Diego Garcia,DG,,,,USD,,,reserved

--- a/data/countries.json
+++ b/data/countries.json
@@ -732,7 +732,7 @@
     "languages": [
       "fra"
     ],
-    "name": "Cote d'Ivoire",
+    "name": "Côte d'Ivoire",
     "status": "assigned"
   },
   {


### PR DESCRIPTION
Theres a typo on Cote, it should be Côte
https://en.wikipedia.org/wiki/Ivory_Coast