### PR TITLE
Prefer assigned countries for alpha2 and alpha3 lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,15 @@ exports.countries = {
 };
 
 _.each(countriesAll, function (country) {
-  exports.countries[country.alpha2] = country;
-  exports.countries[country.alpha3] = country;
+  // prefer assigned country codes over inactive ones
+  var statusAlpha2 = exports.countries[country.alpha2];
+  if (!statusAlpha2 || statusAlpha2 === 'assigned') {
+    exports.countries[country.alpha2] = country;
+  }
+  var statusAlpha3 = exports.countries[country.alpha3];
+  if (!statusAlpha3 || statusAlpha3 === 'assigned') {
+    exports.countries[country.alpha3] = country;
+  }
 });
 
 exports.currencies = {

--- a/test/countries.js
+++ b/test/countries.js
@@ -19,6 +19,10 @@ describe('countries', function () {
       assert.equal( countries.BE.name, 'Belgium');
       assert.equal( countries.US.name, 'United States');
     });
+    it('should prefer assigned alpha2 country codes', function () {
+      assert.equal( countries.SK.name, 'Slovakia');
+      assert.equal( countries.BY.name, 'Belarus');
+    });
   });
 
   describe('alpha3', function () {


### PR DESCRIPTION
Ensures that the alpha2 and alpha3 lookups return currently assigned country codes. Previously, the last defined country was returned, even if it was just a inactive historical record.

See #62, cc: @mattvadrise.