### PR TITLE
Add ISO 3166-1 numeric country codes

### DIFF
--- a/data/countries.csv
+++ b/data/countries.csv
@@ -1,261 +1,261 @@
-name,alpha2,alpha3,ccTLD,countryCallingCodes,currencies,emoji,ioc,languages,status
-Afghanistan,AF,AFG,,+93,AFN,🇦🇫,AFG,pus,assigned
-Albania,AL,ALB,,+355,ALL,🇦🇱,ALB,sqi,assigned
-Algeria,DZ,DZA,,+213,DZD,🇩🇿,ALG,ara,assigned
-American Samoa,AS,ASM,,+1 684,USD,🇦🇸,ASA,"eng,smo",assigned
-Andorra,AD,AND,,+376,EUR,🇦🇩,AND,cat,assigned
-Angola,AO,AGO,,+244,AOA,🇦🇴,ANG,por,assigned
-Anguilla,AI,AIA,,+1 264,XCD,🇦🇮,,eng,assigned
-Antarctica,AQ,ATA,,+672,,🇦🇶,,,assigned
-Antigua And Barbuda,AG,ATG,,+1 268,XCD,🇦🇬,ANT,eng,assigned
-Argentina,AR,ARG,,+54,ARS,🇦🇷,ARG,spa,assigned
-Armenia,AM,ARM,,+374,AMD,🇦🇲,ARM,"hye,rus",assigned
-Aruba,AW,ABW,,+297,AWG,🇦🇼,ARU,nld,assigned
-Ascension Island,AC,,.ac,+247,USD,,SHP,eng,reserved
-Australia,AU,AUS,,+61,AUD,🇦🇺,AUS,eng,assigned
-Austria,AT,AUT,,+43,EUR,🇦🇹,AUT,deu,assigned
-Azerbaijan,AZ,AZE,,+994,AZN,🇦🇿,AZE,aze,assigned
-Bahamas,BS,BHS,,+1 242,BSD,🇧🇸,BAH,eng,assigned
-Bahrain,BH,BHR,,+973,BHD,🇧🇭,BRN,ara,assigned
-Bangladesh,BD,BGD,,+880,BDT,🇧🇩,BAN,ben,assigned
-Barbados,BB,BRB,,+1 246,BBD,🇧🇧,BAR,eng,assigned
-Belarus,BY,BLR,,+375,BYR,🇧🇾,BLR,"bel,rus",assigned
-Belgium,BE,BEL,,+32,EUR,🇧🇪,BEL,"nld,fra,deu",assigned
-Belize,BZ,BLZ,,+501,BZD,🇧🇿,BIZ,eng,assigned
-Benin,BJ,BEN,,+229,XOF,🇧🇯,BEN,fra,assigned
-Bermuda,BM,BMU,,+1 441,BMD,🇧🇲,BER,eng,assigned
-Bhutan,BT,BTN,,+975,"INR,BTN",🇧🇹,BHU,dzo,assigned
-"Bolivia, Plurinational State Of",BO,BOL,,+591,"BOB,BOV",🇧🇴,BOL,"spa,aym,que",assigned
-"Bonaire, Saint Eustatius And Saba",BQ,BES,,+599,USD,🇧🇶,,nld,assigned
-Bosnia & Herzegovina,BA,BIH,,+387,BAM,🇧🇦,BIH,"bos,cre,srp",assigned
-Botswana,BW,BWA,,+267,BWP,🇧🇼,BOT,"eng,tsn",assigned
-Bouvet Island,BV,BVT,,,NOK,🇧🇻,,,assigned
-Brazil,BR,BRA,,+55,BRL,🇧🇷,BRA,por,assigned
-British Indian Ocean Territory,IO,IOT,,+246,USD,🇮🇴,,eng,assigned
-Brunei Darussalam,BN,BRN,,+673,BND,🇧🇳,BRU,"msa,eng",assigned
-Bulgaria,BG,BGR,,+359,BGN,🇧🇬,BUL,bul,assigned
-Burkina Faso,BF,BFA,,+226,XOF,🇧🇫,BUR,fra,assigned
-Burundi,BI,BDI,,+257,BIF,🇧🇮,BDI,fra,assigned
-Cabo Verde,CV,CPV,,+238,CVE,🇨🇻,CPV,por,assigned
-Cambodia,KH,KHM,,+855,KHR,🇰🇭,CAM,khm,assigned
-Cameroon,CM,CMR,,+237,XAF,🇨🇲,CMR,"eng,fra",assigned
-Canada,CA,CAN,,+1,CAD,🇨🇦,CAN,"eng,fra",assigned
-Canary Islands,IC,,,,EUR,,,,reserved
-Cayman Islands,KY,CYM,,+1 345,KYD,🇰🇾,CAY,eng,assigned
-Central African Republic,CF,CAF,,+236,XAF,🇨🇫,CAF,"fra,sag",assigned
-"Ceuta, Mulilla",EA,,,,EUR,,,,reserved
-Chad,TD,TCD,,+235,XAF,🇹🇩,CHA,"ara,fra",assigned
-Chile,CL,CHL,,+56,"CLP,CLF",🇨🇱,CHI,spa,assigned
-China,CN,CHN,,+86,CNY,🇨🇳,CHN,zho,assigned
-Christmas Island,CX,CXR,,+61,AUD,🇨🇽,,eng,assigned
-Clipperton Island,CP,,,,EUR,,,,reserved
-Cocos (Keeling) Islands,CC,CCK,,+61,AUD,🇨🇨,,eng,assigned
-Colombia,CO,COL,,+57,"COP,COU",🇨🇴,COL,spa,assigned
-Comoros,KM,COM,,+269,KMF,🇰🇲,COM,"ara,fra",assigned
-Cook Islands,CK,COK,,+682,NZD,🇨🇰,COK,"eng,mri",assigned
-Costa Rica,CR,CRI,,+506,CRC,🇨🇷,CRC,spa,assigned
-Croatia,HR,HRV,,+385,HRK,🇭🇷,CRO,hrv,assigned
-Cuba,CU,CUB,,+53,"CUP,CUC",🇨🇺,CUB,spa,assigned
-Curacao,CW,CUW,,+599,ANG,🇨🇼,,nld,assigned
-Cyprus,CY,CYP,,+357,EUR,🇨🇾,CYP,"ell,tur",assigned
-Czech Republic,CZ,CZE,,+420,CZK,🇨🇿,CZE,ces,assigned
-Côte d'Ivoire,CI,CIV,,+225,XOF,🇨🇮,CIV,fra,assigned
-Democratic Republic Of Congo,CD,COD,,+243,CDF,🇨🇩,COD,"fra,lin,kon,swa",assigned
-Denmark,DK,DNK,,+45,DKK,🇩🇰,DEN,dan,assigned
-Diego Garcia,DG,,,,USD,,,,reserved
-Djibouti,DJ,DJI,,+253,DJF,🇩🇯,DJI,"ara,fra",assigned
-Dominica,DM,DMA,,+1 767,XCD,🇩🇲,DMA,eng,assigned
-Dominican Republic,DO,DOM,,"+1 809,+1 829,+1 849",DOP,🇩🇴,DOM,spa,assigned
-Ecuador,EC,ECU,,+593,USD,🇪🇨,ECU,"spa,que",assigned
-Egypt,EG,EGY,,+20,EGP,🇪🇬,EGY,ara,assigned
-El Salvador,SV,SLV,,+503,USD,🇸🇻,ESA,spa,assigned
-Equatorial Guinea,GQ,GNQ,,+240,XAF,🇬🇶,GEQ,"spa,fra,por",assigned
-Eritrea,ER,ERI,,+291,ERN,🇪🇷,ERI,"eng,ara,tir",assigned
-Estonia,EE,EST,,+372,EUR,🇪🇪,EST,est,assigned
-Ethiopia,ET,ETH,,+251,ETB,🇪🇹,ETH,amh,assigned
-European Union,EU,,.eu,+388,EUR,🇪🇺,,,reserved
-Falkland Islands,FK,FLK,,+500,FKP,🇫🇰,,eng,assigned
-Faroe Islands,FO,FRO,,+298,DKK,🇫🇴,FAI,"fao,dan",assigned
-Fiji,FJ,FJI,,+679,FJD,🇫🇯,FIJ,"eng,fij",assigned
-Finland,FI,FIN,,+358,EUR,🇫🇮,FIN,"fin,swe",assigned
-France,FR,FRA,,+33,EUR,🇫🇷,FRA,fra,assigned
-"France, Metropolitan",FX,,,+241,EUR,,,fra,reserved
-French Guiana,GF,GUF,,+594,EUR,🇬🇫,,fra,assigned
-French Polynesia,PF,PYF,,+689,XPF,🇵🇫,,fra,assigned
-French Southern Territories,TF,ATF,,,EUR,🇹🇫,,fra,assigned
-Gabon,GA,GAB,,+241,XAF,🇬🇦,GAB,fra,assigned
-Gambia,GM,GMB,,+220,GMD,🇬🇲,GAM,eng,assigned
-Georgia,GE,GEO,,+995,GEL,🇬🇪,GEO,kat,assigned
-Germany,DE,DEU,,+49,EUR,🇩🇪,GER,deu,assigned
-Ghana,GH,GHA,,+233,GHS,🇬🇭,GHA,eng,assigned
-Gibraltar,GI,GIB,,+350,GIP,🇬🇮,,eng,assigned
-Greece,GR,GRC,,+30,EUR,🇬🇷,GRE,ell,assigned
-Greenland,GL,GRL,,+299,DKK,🇬🇱,,kal,assigned
-Grenada,GD,GRD,,+473,XCD,🇬🇩,GRN,eng,assigned
-Guadeloupe,GP,GLP,,+590,EUR,🇬🇵,,fra,assigned
-Guam,GU,GUM,,+1 671,USD,🇬🇺,GUM,eng,assigned
-Guatemala,GT,GTM,,+502,GTQ,🇬🇹,GUA,spa,assigned
-Guernsey,GG,GGY,,+44,GBP,🇬🇬,GCI,fra,assigned
-Guinea,GN,GIN,,+224,GNF,🇬🇳,GUI,fra,assigned
-Guinea-bissau,GW,GNB,,+245,XOF,🇬🇼,GBS,por,assigned
-Guyana,GY,GUY,,+592,GYD,🇬🇾,GUY,eng,assigned
-Haiti,HT,HTI,,+509,"HTG,USD",🇭🇹,HAI,"fra,hat",assigned
-Heard Island And McDonald Islands,HM,HMD,,,AUD,🇭🇲,,,assigned
-Honduras,HN,HND,,+504,HNL,🇭🇳,HON,spa,assigned
-Hong Kong,HK,HKG,,+852,HKD,🇭🇰,HKG,"zho,eng",assigned
-Hungary,HU,HUN,,+36,HUF,🇭🇺,HUN,hun,assigned
-Iceland,IS,ISL,,+354,ISK,🇮🇸,ISL,isl,assigned
-India,IN,IND,,+91,INR,🇮🇳,IND,"eng,hin",assigned
-Indonesia,ID,IDN,,+62,IDR,🇮🇩,INA,ind,assigned
-"Iran, Islamic Republic Of",IR,IRN,,+98,IRR,🇮🇷,IRI,fas,assigned
-Iraq,IQ,IRQ,,+964,IQD,🇮🇶,IRQ,"ara,kur",assigned
-Ireland,IE,IRL,,+353,EUR,🇮🇪,IRL,"eng,gle",assigned
-Isle Of Man,IM,IMN,,+44,GBP,🇮🇲,,"eng,glv",assigned
-Israel,IL,ISR,,+972,ILS,🇮🇱,ISR,"heb,ara,eng",assigned
-Italy,IT,ITA,,+39,EUR,🇮🇹,ITA,ita,assigned
-Jamaica,JM,JAM,,+1 876,JMD,🇯🇲,JAM,eng,assigned
-Japan,JP,JPN,,+81,JPY,🇯🇵,JPN,jpn,assigned
-Jersey,JE,JEY,,+44,GBP,🇯🇪,JCI,"eng,fra",assigned
-Jordan,JO,JOR,,+962,JOD,🇯🇴,JOR,ara,assigned
-Kazakhstan,KZ,KAZ,,"+7,+7 6,+7 7",KZT,🇰🇿,KAZ,"kaz,rus",assigned
-Kenya,KE,KEN,,+254,KES,🇰🇪,KEN,"eng,swa",assigned
-Kiribati,KI,KIR,,+686,AUD,🇰🇮,KIR,eng,assigned
-"Korea, Democratic People's Republic Of",KP,PRK,,+850,KPW,🇰🇵,PRK,kor,assigned
-"Korea, Republic Of",KR,KOR,,+82,KRW,🇰🇷,KOR,kor,assigned
-Kosovo,XK,,,+383,EUR,,KOS,"sqi,srp,bos,tur,rom",user assigned
-Kuwait,KW,KWT,,+965,KWD,🇰🇼,KUW,ara,assigned
-Kyrgyzstan,KG,KGZ,,+996,KGS,🇰🇬,KGZ,rus,assigned
-Lao People's Democratic Republic,LA,LAO,,+856,LAK,🇱🇦,LAO,lao,assigned
-Latvia,LV,LVA,,+371,EUR,🇱🇻,LAT,lav,assigned
-Lebanon,LB,LBN,,+961,LBP,🇱🇧,LIB,"ara,hye",assigned
-Lesotho,LS,LSO,,+266,"LSL,ZAR",🇱🇸,LES,"eng,sot",assigned
-Liberia,LR,LBR,,+231,LRD,🇱🇷,LBR,eng,assigned
-Libya,LY,LBY,,+218,LYD,🇱🇾,LBA,ara,assigned
-Liechtenstein,LI,LIE,,+423,CHF,🇱🇮,LIE,deu,assigned
-Lithuania,LT,LTU,,+370,EUR,🇱🇹,LTU,lit,assigned
-Luxembourg,LU,LUX,,+352,EUR,🇱🇺,LUX,"fra,deu,ltz",assigned
-Macao,MO,MAC,,+853,MOP,🇲🇴,MAC,"zho,por",assigned
-"Macedonia, The Former Yugoslav Republic Of",MK,MKD,,+389,MKD,🇲🇰,MKD,mkd,assigned
-Madagascar,MG,MDG,,+261,MGA,🇲🇬,MAD,"fra,mlg",assigned
-Malawi,MW,MWI,,+265,MWK,🇲🇼,MAW,"eng,nya",assigned
-Malaysia,MY,MYS,,+60,MYR,🇲🇾,MAS,"msa,eng",assigned
-Maldives,MV,MDV,,+960,MVR,🇲🇻,MDV,div,assigned
-Mali,ML,MLI,,+223,XOF,🇲🇱,MLI,fra,assigned
-Malta,MT,MLT,,+356,EUR,🇲🇹,MLT,"mlt,eng",assigned
-Marshall Islands,MH,MHL,,+692,USD,🇲🇭,MHL,"eng,mah",assigned
-Martinique,MQ,MTQ,,+596,EUR,🇲🇶,,,assigned
-Mauritania,MR,MRT,,+222,MRO,🇲🇷,MTN,"ara,fra",assigned
-Mauritius,MU,MUS,,+230,MUR,🇲🇺,MRI,"eng,fra",assigned
-Mayotte,YT,MYT,,+262,EUR,🇾🇹,,fra,assigned
-Mexico,MX,MEX,,+52,"MXN,MXV",🇲🇽,MEX,spa,assigned
-"Micronesia, Federated States Of",FM,FSM,,+691,USD,🇫🇲,FSM,eng,assigned
-Moldova,MD,MDA,,+373,MDL,🇲🇩,MDA,ron,assigned
-Monaco,MC,MCO,,+377,EUR,🇲🇨,MON,fra,assigned
-Mongolia,MN,MNG,,+976,MNT,🇲🇳,MGL,mon,assigned
-Montenegro,ME,MNE,,+382,EUR,🇲🇪,MNE,mot,assigned
-Montserrat,MS,MSR,,+1 664,XCD,🇲🇸,,,assigned
-Morocco,MA,MAR,,+212,MAD,🇲🇦,MAR,ara,assigned
-Mozambique,MZ,MOZ,,+258,MZN,🇲🇿,MOZ,por,assigned
-Myanmar,MM,MMR,,+95,MMK,🇲🇲,MYA,mya,assigned
-Namibia,NA,NAM,,+264,"NAD,ZAR",🇳🇦,NAM,eng,assigned
-Nauru,NR,NRU,,+674,AUD,🇳🇷,NRU,"eng,nau",assigned
-Nepal,NP,NPL,,+977,NPR,🇳🇵,NEP,nep,assigned
-Netherlands,NL,NLD,,+31,EUR,🇳🇱,NED,nld,assigned
-New Caledonia,NC,NCL,,+687,XPF,🇳🇨,,fra,assigned
-New Zealand,NZ,NZL,,+64,NZD,🇳🇿,NZL,eng,assigned
-Nicaragua,NI,NIC,,+505,NIO,🇳🇮,NCA,spa,assigned
-Niger,NE,NER,,+227,XOF,🇳🇪,NIG,fra,assigned
-Nigeria,NG,NGA,,+234,NGN,🇳🇬,NGR,eng,assigned
-Niue,NU,NIU,,+683,NZD,🇳🇺,,eng,assigned
-Norfolk Island,NF,NFK,,+672,AUD,🇳🇫,,eng,assigned
-Northern Mariana Islands,MP,MNP,,+1 670,USD,🇲🇵,,eng,assigned
-Norway,NO,NOR,,+47,NOK,🇳🇴,NOR,nor,assigned
-Oman,OM,OMN,,+968,OMR,🇴🇲,OMA,ara,assigned
-Pakistan,PK,PAK,,+92,PKR,🇵🇰,PAK,"urd,eng",assigned
-Palau,PW,PLW,,+680,USD,🇵🇼,PLW,eng,assigned
-"Palestinian Territory, Occupied",PS,PSE,,+970,"JOD,EGP,ILS",🇵🇸,PLE,ara,assigned
-Panama,PA,PAN,,+507,"PAB,USD",🇵🇦,PAN,spa,assigned
-Papua New Guinea,PG,PNG,,+675,PGK,🇵🇬,PNG,eng,assigned
-Paraguay,PY,PRY,,+595,PYG,🇵🇾,PAR,spa,assigned
-Peru,PE,PER,,+51,PEN,🇵🇪,PER,"spa,aym,que",assigned
-Philippines,PH,PHL,,+63,PHP,🇵🇭,PHI,eng,assigned
-Pitcairn,PN,PCN,,+872,NZD,🇵🇳,,eng,assigned
-Poland,PL,POL,,+48,PLN,🇵🇱,POL,pol,assigned
-Portugal,PT,PRT,,+351,EUR,🇵🇹,POR,por,assigned
-Puerto Rico,PR,PRI,,"+1 787,+1 939",USD,🇵🇷,PUR,"spa,eng",assigned
-Qatar,QA,QAT,,+974,QAR,🇶🇦,QAT,ara,assigned
-Republic Of Congo,CG,COG,,+242,XAF,🇨🇬,CGO,"fra,lin",assigned
-Reunion,RE,REU,,+262,EUR,🇷🇪,,fra,assigned
-Romania,RO,ROU,,+40,RON,🇷🇴,ROU,ron,assigned
-Russian Federation,RU,RUS,,"+7,+7 3,+7 4,+7 8",RUB,🇷🇺,RUS,rus,assigned
-Rwanda,RW,RWA,,+250,RWF,🇷🇼,RWA,"eng,fra,kin",assigned
-Saint Barthélemy,BL,BLM,,+590,EUR,🇧🇱,,fra,assigned
-"Saint Helena, Ascension And Tristan Da Cunha",SH,SHN,,+290,SHP,🇸🇭,,eng,assigned
-Saint Kitts And Nevis,KN,KNA,,+1 869,XCD,🇰🇳,SKN,eng,assigned
-Saint Lucia,LC,LCA,,+1 758,XCD,🇱🇨,LCA,eng,assigned
-Saint Martin,MF,MAF,,+590,EUR,🇲🇫,,fra,assigned
-Saint Pierre And Miquelon,PM,SPM,,+508,EUR,🇵🇲,,eng,assigned
-Saint Vincent And The Grenadines,VC,VCT,,+1 784,XCD,🇻🇨,VIN,eng,assigned
-Samoa,WS,WSM,,+685,WST,🇼🇸,SAM,"eng,smo",assigned
-San Marino,SM,SMR,,+378,EUR,🇸🇲,SMR,ita,assigned
-Sao Tome and Principe,ST,STP,,+239,STD,🇸🇹,STP,por,assigned
-Saudi Arabia,SA,SAU,,+966,SAR,🇸🇦,KSA,ara,assigned
-Senegal,SN,SEN,,+221,XOF,🇸🇳,SEN,fra,assigned
-Serbia,RS,SRB,,+381,RSD,🇷🇸,SRB,srp,assigned
-Seychelles,SC,SYC,,+248,SCR,🇸🇨,SEY,"eng,fra",assigned
-Sierra Leone,SL,SLE,,+232,SLL,🇸🇱,SLE,eng,assigned
-Singapore,SG,SGP,,+65,SGD,🇸🇬,SIN,"eng,zho,msa,tam",assigned
-Sint Maarten,SX,SXM,,+1 721,ANG,🇸🇽,,nld,assigned
-Slovakia,SK,SVK,,+421,EUR,🇸🇰,SVK,slk,assigned
-Slovenia,SI,SVN,,+386,EUR,🇸🇮,SLO,slv,assigned
-Solomon Islands,SB,SLB,,+677,SBD,🇸🇧,SOL,eng,assigned
-Somalia,SO,SOM,,+252,SOS,🇸🇴,SOM,som,assigned
-South Africa,ZA,ZAF,,+27,ZAR,🇿🇦,RSA,"afr,eng,nbl,som,tso,ven,xho,zul",assigned
-South Georgia And The South Sandwich Islands,GS,SGS,,,GBP,🇬🇸,,eng,assigned
-South Sudan,SS,SSD,.ss,+211,SSP,🇸🇸,SSD,eng,assigned
-Spain,ES,ESP,,+34,EUR,🇪🇸,ESP,spa,assigned
-Sri Lanka,LK,LKA,,+94,LKR,🇱🇰,SRI,"sin,tam",assigned
-Sudan,SD,SDN,,+249,SDG,🇸🇩,SUD,"ara,eng",assigned
-Suriname,SR,SUR,,+597,SRD,🇸🇷,SUR,nld,assigned
-Svalbard And Jan Mayen,SJ,SJM,,+47,NOK,🇸🇯,,,assigned
-Swaziland,SZ,SWZ,,+268,SZL,🇸🇿,SWZ,"eng,ssw",assigned
-Sweden,SE,SWE,,+46,SEK,🇸🇪,SWE,swe,assigned
-Switzerland,CH,CHE,,+41,"CHF,CHE,CHW",🇨🇭,SUI,"deu,fra,ita,roh",assigned
-Syrian Arab Republic,SY,SYR,,+963,SYP,🇸🇾,SYR,ara,assigned
-Taiwan,TW,TWN,,+886,TWD,🇹🇼,TPE,zho,assigned
-Tajikistan,TJ,TJK,,+992,TJS,🇹🇯,TJK,"tgk,rus",assigned
-"Tanzania, United Republic Of",TZ,TZA,,+255,TZS,🇹🇿,TAN,"swa,eng",assigned
-Thailand,TH,THA,,+66,THB,🇹🇭,THA,tha,assigned
-"Timor-Leste, Democratic Republic of",TL,TLS,,+670,USD,🇹🇱,TLS,por,assigned
-Togo,TG,TGO,,+228,XOF,🇹🇬,TOG,fra,assigned
-Tokelau,TK,TKL,,+690,NZD,🇹🇰,,eng,assigned
-Tonga,TO,TON,,+676,TOP,🇹🇴,TGA,eng,assigned
-Trinidad And Tobago,TT,TTO,,+1 868,TTD,🇹🇹,TTO,eng,assigned
-Tristan de Cunha,TA,,,+290,GBP,,,,reserved
-Tunisia,TN,TUN,,+216,TND,🇹🇳,TUN,ara,assigned
-Turkey,TR,TUR,,+90,TRY,🇹🇷,TUR,tur,assigned
-Turkmenistan,TM,TKM,,+993,TMT,🇹🇲,TKM,"tuk,rus",assigned
-Turks And Caicos Islands,TC,TCA,,+1 649,USD,🇹🇨,,eng,assigned
-Tuvalu,TV,TUV,,+688,AUD,🇹🇻,TUV,eng,assigned
-Uganda,UG,UGA,,+256,UGX,🇺🇬,UGA,"eng,swa",assigned
-Ukraine,UA,UKR,,+380,UAH,🇺🇦,UKR,"ukr,rus",assigned
-United Arab Emirates,AE,ARE,,+971,AED,🇦🇪,UAE,ara,assigned
-United Kingdom,GB,GBR,,+44,GBP,🇬🇧,GBR,"eng,cor,gle,gla,cym",assigned
-United Kingdom,UK,,.uk,,GBP,,,"eng,cor,gle,gla,cym",reserved
-United States,US,USA,,+1,USD,🇺🇸,USA,eng,assigned
-United States Minor Outlying Islands,UM,UMI,,+1,USD,🇺🇲,,eng,assigned
-Uruguay,UY,URY,,+598,"UYU,UYI",🇺🇾,URU,spa,assigned
-USSR,SU,,.su,,RUB,,,rus,reserved
-Uzbekistan,UZ,UZB,,+998,UZS,🇺🇿,UZB,"uzb,rus",assigned
-Vanuatu,VU,VUT,,+678,VUV,🇻🇺,VAN,"bis,eng,fra",assigned
-Vatican City State,VA,VAT,,"+379,+39",EUR,🇻🇦,,ita,assigned
-"Venezuela, Bolivarian Republic Of",VE,VEN,,+58,VEF,🇻🇪,VEN,spa,assigned
-Viet Nam,VN,VNM,,+84,VND,🇻🇳,VIE,vie,assigned
-Virgin Islands (British),VG,VGB,,+1 284,USD,🇻🇬,IVB,eng,assigned
-Virgin Islands (US),VI,VIR,,+1 340,USD,🇻🇮,ISV,eng,assigned
-Wallis And Futuna,WF,WLF,,+681,XPF,🇼🇫,,fra,assigned
-Western Sahara,EH,ESH,,+212,MAD,🇪🇭,,,assigned
-Yemen,YE,YEM,,+967,YER,🇾🇪,YEM,ara,assigned
-Zambia,ZM,ZMB,,+260,ZMW,🇿🇲,ZAM,eng,assigned
-Zimbabwe,ZW,ZWE,,+263,"USD,ZAR,BWP,GBP,EUR",🇿🇼,ZIM,"eng,sna,nde",assigned
-Åland Islands,AX,ALA,,+358,EUR,🇦🇽,,swe,assigned
+name,alpha2,alpha3,ccTLD,countryCallingCodes,currencies,emoji,ioc,languages,status,numeric
+Afghanistan,AF,AFG,,+93,AFN,🇦🇫,AFG,pus,assigned,004
+Albania,AL,ALB,,+355,ALL,🇦🇱,ALB,sqi,assigned,008
+Algeria,DZ,DZA,,+213,DZD,🇩🇿,ALG,ara,assigned,012
+American Samoa,AS,ASM,,+1 684,USD,🇦🇸,ASA,"eng,smo",assigned,016
+Andorra,AD,AND,,+376,EUR,🇦🇩,AND,cat,assigned,020
+Angola,AO,AGO,,+244,AOA,🇦🇴,ANG,por,assigned,024
+Anguilla,AI,AIA,,+1 264,XCD,🇦🇮,,eng,assigned,660
+Antarctica,AQ,ATA,,+672,,🇦🇶,,,assigned,010
+Antigua And Barbuda,AG,ATG,,+1 268,XCD,🇦🇬,ANT,eng,assigned,028
+Argentina,AR,ARG,,+54,ARS,🇦🇷,ARG,spa,assigned,032
+Armenia,AM,ARM,,+374,AMD,🇦🇲,ARM,"hye,rus",assigned,051
+Aruba,AW,ABW,,+297,AWG,🇦🇼,ARU,nld,assigned,533
+Ascension Island,AC,,.ac,+247,USD,,SHP,eng,reserved,
+Australia,AU,AUS,,+61,AUD,🇦🇺,AUS,eng,assigned,036
+Austria,AT,AUT,,+43,EUR,🇦🇹,AUT,deu,assigned,040
+Azerbaijan,AZ,AZE,,+994,AZN,🇦🇿,AZE,aze,assigned,031
+Bahamas,BS,BHS,,+1 242,BSD,🇧🇸,BAH,eng,assigned,044
+Bahrain,BH,BHR,,+973,BHD,🇧🇭,BRN,ara,assigned,048
+Bangladesh,BD,BGD,,+880,BDT,🇧🇩,BAN,ben,assigned,050
+Barbados,BB,BRB,,+1 246,BBD,🇧🇧,BAR,eng,assigned,052
+Belarus,BY,BLR,,+375,BYR,🇧🇾,BLR,"bel,rus",assigned,112
+Belgium,BE,BEL,,+32,EUR,🇧🇪,BEL,"nld,fra,deu",assigned,056
+Belize,BZ,BLZ,,+501,BZD,🇧🇿,BIZ,eng,assigned,084
+Benin,BJ,BEN,,+229,XOF,🇧🇯,BEN,fra,assigned,204
+Bermuda,BM,BMU,,+1 441,BMD,🇧🇲,BER,eng,assigned,060
+Bhutan,BT,BTN,,+975,"INR,BTN",🇧🇹,BHU,dzo,assigned,064
+"Bolivia, Plurinational State Of",BO,BOL,,+591,"BOB,BOV",🇧🇴,BOL,"spa,aym,que",assigned,068
+"Bonaire, Saint Eustatius And Saba",BQ,BES,,+599,USD,🇧🇶,,nld,assigned,535
+Bosnia & Herzegovina,BA,BIH,,+387,BAM,🇧🇦,BIH,"bos,cre,srp",assigned,070
+Botswana,BW,BWA,,+267,BWP,🇧🇼,BOT,"eng,tsn",assigned,072
+Bouvet Island,BV,BVT,,,NOK,🇧🇻,,,assigned,074
+Brazil,BR,BRA,,+55,BRL,🇧🇷,BRA,por,assigned,076
+British Indian Ocean Territory,IO,IOT,,+246,USD,🇮🇴,,eng,assigned,086
+Brunei Darussalam,BN,BRN,,+673,BND,🇧🇳,BRU,"msa,eng",assigned,096
+Bulgaria,BG,BGR,,+359,BGN,🇧🇬,BUL,bul,assigned,100
+Burkina Faso,BF,BFA,,+226,XOF,🇧🇫,BUR,fra,assigned,854
+Burundi,BI,BDI,,+257,BIF,🇧🇮,BDI,fra,assigned,108
+Cabo Verde,CV,CPV,,+238,CVE,🇨🇻,CPV,por,assigned,132
+Cambodia,KH,KHM,,+855,KHR,🇰🇭,CAM,khm,assigned,116
+Cameroon,CM,CMR,,+237,XAF,🇨🇲,CMR,"eng,fra",assigned,120
+Canada,CA,CAN,,+1,CAD,🇨🇦,CAN,"eng,fra",assigned,124
+Canary Islands,IC,,,,EUR,,,,reserved,
+Cayman Islands,KY,CYM,,+1 345,KYD,🇰🇾,CAY,eng,assigned,136
+Central African Republic,CF,CAF,,+236,XAF,🇨🇫,CAF,"fra,sag",assigned,140
+"Ceuta, Mulilla",EA,,,,EUR,,,,reserved,
+Chad,TD,TCD,,+235,XAF,🇹🇩,CHA,"ara,fra",assigned,148
+Chile,CL,CHL,,+56,"CLP,CLF",🇨🇱,CHI,spa,assigned,152
+China,CN,CHN,,+86,CNY,🇨🇳,CHN,zho,assigned,156
+Christmas Island,CX,CXR,,+61,AUD,🇨🇽,,eng,assigned,162
+Clipperton Island,CP,,,,EUR,,,,reserved,
+Cocos (Keeling) Islands,CC,CCK,,+61,AUD,🇨🇨,,eng,assigned,166
+Colombia,CO,COL,,+57,"COP,COU",🇨🇴,COL,spa,assigned,170
+Comoros,KM,COM,,+269,KMF,🇰🇲,COM,"ara,fra",assigned,174
+Cook Islands,CK,COK,,+682,NZD,🇨🇰,COK,"eng,mri",assigned,184
+Costa Rica,CR,CRI,,+506,CRC,🇨🇷,CRC,spa,assigned,188
+Croatia,HR,HRV,,+385,HRK,🇭🇷,CRO,hrv,assigned,191
+Cuba,CU,CUB,,+53,"CUP,CUC",🇨🇺,CUB,spa,assigned,192
+Curacao,CW,CUW,,+599,ANG,🇨🇼,,nld,assigned,531
+Cyprus,CY,CYP,,+357,EUR,🇨🇾,CYP,"ell,tur",assigned,196
+Czech Republic,CZ,CZE,,+420,CZK,🇨🇿,CZE,ces,assigned,203
+Côte d'Ivoire,CI,CIV,,+225,XOF,🇨🇮,CIV,fra,assigned,384
+Democratic Republic Of Congo,CD,COD,,+243,CDF,🇨🇩,COD,"fra,lin,kon,swa",assigned,180
+Denmark,DK,DNK,,+45,DKK,🇩🇰,DEN,dan,assigned,208
+Diego Garcia,DG,,,,USD,,,,reserved,
+Djibouti,DJ,DJI,,+253,DJF,🇩🇯,DJI,"ara,fra",assigned,262
+Dominica,DM,DMA,,+1 767,XCD,🇩🇲,DMA,eng,assigned,212
+Dominican Republic,DO,DOM,,"+1 809,+1 829,+1 849",DOP,🇩🇴,DOM,spa,assigned,214
+Ecuador,EC,ECU,,+593,USD,🇪🇨,ECU,"spa,que",assigned,218
+Egypt,EG,EGY,,+20,EGP,🇪🇬,EGY,ara,assigned,818
+El Salvador,SV,SLV,,+503,USD,🇸🇻,ESA,spa,assigned,222
+Equatorial Guinea,GQ,GNQ,,+240,XAF,🇬🇶,GEQ,"spa,fra,por",assigned,226
+Eritrea,ER,ERI,,+291,ERN,🇪🇷,ERI,"eng,ara,tir",assigned,232
+Estonia,EE,EST,,+372,EUR,🇪🇪,EST,est,assigned,233
+Ethiopia,ET,ETH,,+251,ETB,🇪🇹,ETH,amh,assigned,231
+European Union,EU,,.eu,+388,EUR,🇪🇺,,,reserved,
+Falkland Islands,FK,FLK,,+500,FKP,🇫🇰,,eng,assigned,238
+Faroe Islands,FO,FRO,,+298,DKK,🇫🇴,FAI,"fao,dan",assigned,234
+Fiji,FJ,FJI,,+679,FJD,🇫🇯,FIJ,"eng,fij",assigned,242
+Finland,FI,FIN,,+358,EUR,🇫🇮,FIN,"fin,swe",assigned,246
+France,FR,FRA,,+33,EUR,🇫🇷,FRA,fra,assigned,250
+"France, Metropolitan",FX,,,+241,EUR,,,fra,reserved,
+French Guiana,GF,GUF,,+594,EUR,🇬🇫,,fra,assigned,254
+French Polynesia,PF,PYF,,+689,XPF,🇵🇫,,fra,assigned,258
+French Southern Territories,TF,ATF,,,EUR,🇹🇫,,fra,assigned,260
+Gabon,GA,GAB,,+241,XAF,🇬🇦,GAB,fra,assigned,266
+Gambia,GM,GMB,,+220,GMD,🇬🇲,GAM,eng,assigned,270
+Georgia,GE,GEO,,+995,GEL,🇬🇪,GEO,kat,assigned,268
+Germany,DE,DEU,,+49,EUR,🇩🇪,GER,deu,assigned,276
+Ghana,GH,GHA,,+233,GHS,🇬🇭,GHA,eng,assigned,288
+Gibraltar,GI,GIB,,+350,GIP,🇬🇮,,eng,assigned,292
+Greece,GR,GRC,,+30,EUR,🇬🇷,GRE,ell,assigned,300
+Greenland,GL,GRL,,+299,DKK,🇬🇱,,kal,assigned,304
+Grenada,GD,GRD,,+473,XCD,🇬🇩,GRN,eng,assigned,308
+Guadeloupe,GP,GLP,,+590,EUR,🇬🇵,,fra,assigned,312
+Guam,GU,GUM,,+1 671,USD,🇬🇺,GUM,eng,assigned,316
+Guatemala,GT,GTM,,+502,GTQ,🇬🇹,GUA,spa,assigned,320
+Guernsey,GG,GGY,,+44,GBP,🇬🇬,GCI,fra,assigned,831
+Guinea,GN,GIN,,+224,GNF,🇬🇳,GUI,fra,assigned,324
+Guinea-bissau,GW,GNB,,+245,XOF,🇬🇼,GBS,por,assigned,624
+Guyana,GY,GUY,,+592,GYD,🇬🇾,GUY,eng,assigned,328
+Haiti,HT,HTI,,+509,"HTG,USD",🇭🇹,HAI,"fra,hat",assigned,332
+Heard Island And McDonald Islands,HM,HMD,,,AUD,🇭🇲,,,assigned,334
+Honduras,HN,HND,,+504,HNL,🇭🇳,HON,spa,assigned,340
+Hong Kong,HK,HKG,,+852,HKD,🇭🇰,HKG,"zho,eng",assigned,344
+Hungary,HU,HUN,,+36,HUF,🇭🇺,HUN,hun,assigned,348
+Iceland,IS,ISL,,+354,ISK,🇮🇸,ISL,isl,assigned,352
+India,IN,IND,,+91,INR,🇮🇳,IND,"eng,hin",assigned,356
+Indonesia,ID,IDN,,+62,IDR,🇮🇩,INA,ind,assigned,360
+"Iran, Islamic Republic Of",IR,IRN,,+98,IRR,🇮🇷,IRI,fas,assigned,364
+Iraq,IQ,IRQ,,+964,IQD,🇮🇶,IRQ,"ara,kur",assigned,368
+Ireland,IE,IRL,,+353,EUR,🇮🇪,IRL,"eng,gle",assigned,372
+Isle Of Man,IM,IMN,,+44,GBP,🇮🇲,,"eng,glv",assigned,833
+Israel,IL,ISR,,+972,ILS,🇮🇱,ISR,"heb,ara,eng",assigned,376
+Italy,IT,ITA,,+39,EUR,🇮🇹,ITA,ita,assigned,380
+Jamaica,JM,JAM,,+1 876,JMD,🇯🇲,JAM,eng,assigned,388
+Japan,JP,JPN,,+81,JPY,🇯🇵,JPN,jpn,assigned,392
+Jersey,JE,JEY,,+44,GBP,🇯🇪,JCI,"eng,fra",assigned,832
+Jordan,JO,JOR,,+962,JOD,🇯🇴,JOR,ara,assigned,400
+Kazakhstan,KZ,KAZ,,"+7,+7 6,+7 7",KZT,🇰🇿,KAZ,"kaz,rus",assigned,398
+Kenya,KE,KEN,,+254,KES,🇰🇪,KEN,"eng,swa",assigned,404
+Kiribati,KI,KIR,,+686,AUD,🇰🇮,KIR,eng,assigned,296
+"Korea, Democratic People's Republic Of",KP,PRK,,+850,KPW,🇰🇵,PRK,kor,assigned,408
+"Korea, Republic Of",KR,KOR,,+82,KRW,🇰🇷,KOR,kor,assigned,410
+Kosovo,XK,,,+383,EUR,,KOS,"sqi,srp,bos,tur,rom",user assigned,
+Kuwait,KW,KWT,,+965,KWD,🇰🇼,KUW,ara,assigned,414
+Kyrgyzstan,KG,KGZ,,+996,KGS,🇰🇬,KGZ,rus,assigned,417
+Lao People's Democratic Republic,LA,LAO,,+856,LAK,🇱🇦,LAO,lao,assigned,418
+Latvia,LV,LVA,,+371,EUR,🇱🇻,LAT,lav,assigned,428
+Lebanon,LB,LBN,,+961,LBP,🇱🇧,LIB,"ara,hye",assigned,422
+Lesotho,LS,LSO,,+266,"LSL,ZAR",🇱🇸,LES,"eng,sot",assigned,426
+Liberia,LR,LBR,,+231,LRD,🇱🇷,LBR,eng,assigned,430
+Libya,LY,LBY,,+218,LYD,🇱🇾,LBA,ara,assigned,434
+Liechtenstein,LI,LIE,,+423,CHF,🇱🇮,LIE,deu,assigned,438
+Lithuania,LT,LTU,,+370,EUR,🇱🇹,LTU,lit,assigned,440
+Luxembourg,LU,LUX,,+352,EUR,🇱🇺,LUX,"fra,deu,ltz",assigned,442
+Macao,MO,MAC,,+853,MOP,🇲🇴,MAC,"zho,por",assigned,446
+"Macedonia, The Former Yugoslav Republic Of",MK,MKD,,+389,MKD,🇲🇰,MKD,mkd,assigned,807
+Madagascar,MG,MDG,,+261,MGA,🇲🇬,MAD,"fra,mlg",assigned,450
+Malawi,MW,MWI,,+265,MWK,🇲🇼,MAW,"eng,nya",assigned,454
+Malaysia,MY,MYS,,+60,MYR,🇲🇾,MAS,"msa,eng",assigned,458
+Maldives,MV,MDV,,+960,MVR,🇲🇻,MDV,div,assigned,462
+Mali,ML,MLI,,+223,XOF,🇲🇱,MLI,fra,assigned,466
+Malta,MT,MLT,,+356,EUR,🇲🇹,MLT,"mlt,eng",assigned,470
+Marshall Islands,MH,MHL,,+692,USD,🇲🇭,MHL,"eng,mah",assigned,584
+Martinique,MQ,MTQ,,+596,EUR,🇲🇶,,,assigned,474
+Mauritania,MR,MRT,,+222,MRO,🇲🇷,MTN,"ara,fra",assigned,478
+Mauritius,MU,MUS,,+230,MUR,🇲🇺,MRI,"eng,fra",assigned,480
+Mayotte,YT,MYT,,+262,EUR,🇾🇹,,fra,assigned,175
+Mexico,MX,MEX,,+52,"MXN,MXV",🇲🇽,MEX,spa,assigned,484
+"Micronesia, Federated States Of",FM,FSM,,+691,USD,🇫🇲,FSM,eng,assigned,583
+Moldova,MD,MDA,,+373,MDL,🇲🇩,MDA,ron,assigned,498
+Monaco,MC,MCO,,+377,EUR,🇲🇨,MON,fra,assigned,492
+Mongolia,MN,MNG,,+976,MNT,🇲🇳,MGL,mon,assigned,496
+Montenegro,ME,MNE,,+382,EUR,🇲🇪,MNE,mot,assigned,499
+Montserrat,MS,MSR,,+1 664,XCD,🇲🇸,,,assigned,500
+Morocco,MA,MAR,,+212,MAD,🇲🇦,MAR,ara,assigned,504
+Mozambique,MZ,MOZ,,+258,MZN,🇲🇿,MOZ,por,assigned,508
+Myanmar,MM,MMR,,+95,MMK,🇲🇲,MYA,mya,assigned,104
+Namibia,NA,NAM,,+264,"NAD,ZAR",🇳🇦,NAM,eng,assigned,516
+Nauru,NR,NRU,,+674,AUD,🇳🇷,NRU,"eng,nau",assigned,520
+Nepal,NP,NPL,,+977,NPR,🇳🇵,NEP,nep,assigned,524
+Netherlands,NL,NLD,,+31,EUR,🇳🇱,NED,nld,assigned,528
+New Caledonia,NC,NCL,,+687,XPF,🇳🇨,,fra,assigned,540
+New Zealand,NZ,NZL,,+64,NZD,🇳🇿,NZL,eng,assigned,554
+Nicaragua,NI,NIC,,+505,NIO,🇳🇮,NCA,spa,assigned,558
+Niger,NE,NER,,+227,XOF,🇳🇪,NIG,fra,assigned,562
+Nigeria,NG,NGA,,+234,NGN,🇳🇬,NGR,eng,assigned,566
+Niue,NU,NIU,,+683,NZD,🇳🇺,,eng,assigned,570
+Norfolk Island,NF,NFK,,+672,AUD,🇳🇫,,eng,assigned,574
+Northern Mariana Islands,MP,MNP,,+1 670,USD,🇲🇵,,eng,assigned,580
+Norway,NO,NOR,,+47,NOK,🇳🇴,NOR,nor,assigned,578
+Oman,OM,OMN,,+968,OMR,🇴🇲,OMA,ara,assigned,512
+Pakistan,PK,PAK,,+92,PKR,🇵🇰,PAK,"urd,eng",assigned,586
+Palau,PW,PLW,,+680,USD,🇵🇼,PLW,eng,assigned,585
+"Palestinian Territory, Occupied",PS,PSE,,+970,"JOD,EGP,ILS",🇵🇸,PLE,ara,assigned,275
+Panama,PA,PAN,,+507,"PAB,USD",🇵🇦,PAN,spa,assigned,591
+Papua New Guinea,PG,PNG,,+675,PGK,🇵🇬,PNG,eng,assigned,598
+Paraguay,PY,PRY,,+595,PYG,🇵🇾,PAR,spa,assigned,600
+Peru,PE,PER,,+51,PEN,🇵🇪,PER,"spa,aym,que",assigned,604
+Philippines,PH,PHL,,+63,PHP,🇵🇭,PHI,eng,assigned,608
+Pitcairn,PN,PCN,,+872,NZD,🇵🇳,,eng,assigned,612
+Poland,PL,POL,,+48,PLN,🇵🇱,POL,pol,assigned,616
+Portugal,PT,PRT,,+351,EUR,🇵🇹,POR,por,assigned,620
+Puerto Rico,PR,PRI,,"+1 787,+1 939",USD,🇵🇷,PUR,"spa,eng",assigned,630
+Qatar,QA,QAT,,+974,QAR,🇶🇦,QAT,ara,assigned,634
+Republic Of Congo,CG,COG,,+242,XAF,🇨🇬,CGO,"fra,lin",assigned,178
+Reunion,RE,REU,,+262,EUR,🇷🇪,,fra,assigned,638
+Romania,RO,ROU,,+40,RON,🇷🇴,ROU,ron,assigned,642
+Russian Federation,RU,RUS,,"+7,+7 3,+7 4,+7 8",RUB,🇷🇺,RUS,rus,assigned,643
+Rwanda,RW,RWA,,+250,RWF,🇷🇼,RWA,"eng,fra,kin",assigned,646
+Saint Barthélemy,BL,BLM,,+590,EUR,🇧🇱,,fra,assigned,652
+"Saint Helena, Ascension And Tristan Da Cunha",SH,SHN,,+290,SHP,🇸🇭,,eng,assigned,654
+Saint Kitts And Nevis,KN,KNA,,+1 869,XCD,🇰🇳,SKN,eng,assigned,659
+Saint Lucia,LC,LCA,,+1 758,XCD,🇱🇨,LCA,eng,assigned,662
+Saint Martin,MF,MAF,,+590,EUR,🇲🇫,,fra,assigned,663
+Saint Pierre And Miquelon,PM,SPM,,+508,EUR,🇵🇲,,eng,assigned,666
+Saint Vincent And The Grenadines,VC,VCT,,+1 784,XCD,🇻🇨,VIN,eng,assigned,670
+Samoa,WS,WSM,,+685,WST,🇼🇸,SAM,"eng,smo",assigned,882
+San Marino,SM,SMR,,+378,EUR,🇸🇲,SMR,ita,assigned,674
+Sao Tome and Principe,ST,STP,,+239,STD,🇸🇹,STP,por,assigned,678
+Saudi Arabia,SA,SAU,,+966,SAR,🇸🇦,KSA,ara,assigned,682
+Senegal,SN,SEN,,+221,XOF,🇸🇳,SEN,fra,assigned,686
+Serbia,RS,SRB,,+381,RSD,🇷🇸,SRB,srp,assigned,688
+Seychelles,SC,SYC,,+248,SCR,🇸🇨,SEY,"eng,fra",assigned,690
+Sierra Leone,SL,SLE,,+232,SLL,🇸🇱,SLE,eng,assigned,694
+Singapore,SG,SGP,,+65,SGD,🇸🇬,SIN,"eng,zho,msa,tam",assigned,702
+Sint Maarten,SX,SXM,,+1 721,ANG,🇸🇽,,nld,assigned,534
+Slovakia,SK,SVK,,+421,EUR,🇸🇰,SVK,slk,assigned,703
+Slovenia,SI,SVN,,+386,EUR,🇸🇮,SLO,slv,assigned,705
+Solomon Islands,SB,SLB,,+677,SBD,🇸🇧,SOL,eng,assigned,090
+Somalia,SO,SOM,,+252,SOS,🇸🇴,SOM,som,assigned,706
+South Africa,ZA,ZAF,,+27,ZAR,🇿🇦,RSA,"afr,eng,nbl,som,tso,ven,xho,zul",assigned,710
+South Georgia And The South Sandwich Islands,GS,SGS,,,GBP,🇬🇸,,eng,assigned,239
+South Sudan,SS,SSD,.ss,+211,SSP,🇸🇸,SSD,eng,assigned,728
+Spain,ES,ESP,,+34,EUR,🇪🇸,ESP,spa,assigned,724
+Sri Lanka,LK,LKA,,+94,LKR,🇱🇰,SRI,"sin,tam",assigned,144
+Sudan,SD,SDN,,+249,SDG,🇸🇩,SUD,"ara,eng",assigned,729
+Suriname,SR,SUR,,+597,SRD,🇸🇷,SUR,nld,assigned,740
+Svalbard And Jan Mayen,SJ,SJM,,+47,NOK,🇸🇯,,,assigned,744
+Swaziland,SZ,SWZ,,+268,SZL,🇸🇿,SWZ,"eng,ssw",assigned,748
+Sweden,SE,SWE,,+46,SEK,🇸🇪,SWE,swe,assigned,752
+Switzerland,CH,CHE,,+41,"CHF,CHE,CHW",🇨🇭,SUI,"deu,fra,ita,roh",assigned,756
+Syrian Arab Republic,SY,SYR,,+963,SYP,🇸🇾,SYR,ara,assigned,760
+Taiwan,TW,TWN,,+886,TWD,🇹🇼,TPE,zho,assigned,158
+Tajikistan,TJ,TJK,,+992,TJS,🇹🇯,TJK,"tgk,rus",assigned,762
+"Tanzania, United Republic Of",TZ,TZA,,+255,TZS,🇹🇿,TAN,"swa,eng",assigned,834
+Thailand,TH,THA,,+66,THB,🇹🇭,THA,tha,assigned,764
+"Timor-Leste, Democratic Republic of",TL,TLS,,+670,USD,🇹🇱,TLS,por,assigned,626
+Togo,TG,TGO,,+228,XOF,🇹🇬,TOG,fra,assigned,768
+Tokelau,TK,TKL,,+690,NZD,🇹🇰,,eng,assigned,772
+Tonga,TO,TON,,+676,TOP,🇹🇴,TGA,eng,assigned,776
+Trinidad And Tobago,TT,TTO,,+1 868,TTD,🇹🇹,TTO,eng,assigned,780
+Tristan de Cunha,TA,,,+290,GBP,,,,reserved,
+Tunisia,TN,TUN,,+216,TND,🇹🇳,TUN,ara,assigned,788
+Turkey,TR,TUR,,+90,TRY,🇹🇷,TUR,tur,assigned,792
+Turkmenistan,TM,TKM,,+993,TMT,🇹🇲,TKM,"tuk,rus",assigned,795
+Turks And Caicos Islands,TC,TCA,,+1 649,USD,🇹🇨,,eng,assigned,796
+Tuvalu,TV,TUV,,+688,AUD,🇹🇻,TUV,eng,assigned,798
+Uganda,UG,UGA,,+256,UGX,🇺🇬,UGA,"eng,swa",assigned,800
+Ukraine,UA,UKR,,+380,UAH,🇺🇦,UKR,"ukr,rus",assigned,804
+United Arab Emirates,AE,ARE,,+971,AED,🇦🇪,UAE,ara,assigned,784
+United Kingdom,GB,GBR,,+44,GBP,🇬🇧,GBR,"eng,cor,gle,gla,cym",assigned,826
+United Kingdom,UK,,.uk,,GBP,,,"eng,cor,gle,gla,cym",reserved,
+United States,US,USA,,+1,USD,🇺🇸,USA,eng,assigned,840
+United States Minor Outlying Islands,UM,UMI,,+1,USD,🇺🇲,,eng,assigned,581
+Uruguay,UY,URY,,+598,"UYU,UYI",🇺🇾,URU,spa,assigned,858
+USSR,SU,,.su,,RUB,,,rus,reserved,
+Uzbekistan,UZ,UZB,,+998,UZS,🇺🇿,UZB,"uzb,rus",assigned,860
+Vanuatu,VU,VUT,,+678,VUV,🇻🇺,VAN,"bis,eng,fra",assigned,548
+Vatican City State,VA,VAT,,"+379,+39",EUR,🇻🇦,,ita,assigned,336
+"Venezuela, Bolivarian Republic Of",VE,VEN,,+58,VEF,🇻🇪,VEN,spa,assigned,862
+Viet Nam,VN,VNM,,+84,VND,🇻🇳,VIE,vie,assigned,704
+Virgin Islands (British),VG,VGB,,+1 284,USD,🇻🇬,IVB,eng,assigned,092
+Virgin Islands (US),VI,VIR,,+1 340,USD,🇻🇮,ISV,eng,assigned,850
+Wallis And Futuna,WF,WLF,,+681,XPF,🇼🇫,,fra,assigned,876
+Western Sahara,EH,ESH,,+212,MAD,🇪🇭,,,assigned,732
+Yemen,YE,YEM,,+967,YER,🇾🇪,YEM,ara,assigned,887
+Zambia,ZM,ZMB,,+260,ZMW,🇿🇲,ZAM,eng,assigned,894
+Zimbabwe,ZW,ZWE,,+263,"USD,ZAR,BWP,GBP,EUR",🇿🇼,ZIM,"eng,sna,nde",assigned,716
+Åland Islands,AX,ALA,,+358,EUR,🇦🇽,,swe,assigned,248

--- a/data/countries.json
+++ b/data/countries.json
@@ -14,6 +14,7 @@
       "eng"
     ],
     "name": "Ascension Island",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -31,6 +32,7 @@
       "cat"
     ],
     "name": "Andorra",
+    "numeric": "020",
     "status": "assigned"
   },
   {
@@ -48,6 +50,7 @@
       "ara"
     ],
     "name": "United Arab Emirates",
+    "numeric": "784",
     "status": "assigned"
   },
   {
@@ -65,6 +68,7 @@
       "pus"
     ],
     "name": "Afghanistan",
+    "numeric": "004",
     "status": "assigned"
   },
   {
@@ -82,6 +86,7 @@
       "eng"
     ],
     "name": "Antigua And Barbuda",
+    "numeric": "028",
     "status": "assigned"
   },
   {
@@ -99,6 +104,7 @@
       "eng"
     ],
     "name": "Anguilla",
+    "numeric": "660",
     "status": "assigned"
   },
   {
@@ -109,6 +115,7 @@
     "ioc": "",
     "languages": [],
     "name": "French Afar and Issas",
+    "numeric": "660",
     "status": "deleted"
   },
   {
@@ -126,6 +133,7 @@
       "sqi"
     ],
     "name": "Albania",
+    "numeric": "008",
     "status": "assigned"
   },
   {
@@ -144,6 +152,7 @@
       "rus"
     ],
     "name": "Armenia",
+    "numeric": "051",
     "status": "assigned"
   },
   {
@@ -154,6 +163,7 @@
     "ioc": "",
     "languages": [],
     "name": "Netherlands Antilles",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -171,6 +181,7 @@
       "por"
     ],
     "name": "Angola",
+    "numeric": "024",
     "status": "assigned"
   },
   {
@@ -184,6 +195,7 @@
     "ioc": "",
     "languages": [],
     "name": "Antarctica",
+    "numeric": "010",
     "status": "assigned"
   },
   {
@@ -201,6 +213,7 @@
       "spa"
     ],
     "name": "Argentina",
+    "numeric": "032",
     "status": "assigned"
   },
   {
@@ -219,6 +232,7 @@
       "smo"
     ],
     "name": "American Samoa",
+    "numeric": "016",
     "status": "assigned"
   },
   {
@@ -236,6 +250,7 @@
       "deu"
     ],
     "name": "Austria",
+    "numeric": "040",
     "status": "assigned"
   },
   {
@@ -253,6 +268,7 @@
       "eng"
     ],
     "name": "Australia",
+    "numeric": "036",
     "status": "assigned"
   },
   {
@@ -270,6 +286,7 @@
       "nld"
     ],
     "name": "Aruba",
+    "numeric": "533",
     "status": "assigned"
   },
   {
@@ -287,6 +304,7 @@
       "swe"
     ],
     "name": "Åland Islands",
+    "numeric": "248",
     "status": "assigned"
   },
   {
@@ -304,6 +322,7 @@
       "aze"
     ],
     "name": "Azerbaijan",
+    "numeric": "031",
     "status": "assigned"
   },
   {
@@ -323,6 +342,7 @@
       "srp"
     ],
     "name": "Bosnia & Herzegovina",
+    "numeric": "070",
     "status": "assigned"
   },
   {
@@ -340,6 +360,7 @@
       "eng"
     ],
     "name": "Barbados",
+    "numeric": "052",
     "status": "assigned"
   },
   {
@@ -357,6 +378,7 @@
       "ben"
     ],
     "name": "Bangladesh",
+    "numeric": "050",
     "status": "assigned"
   },
   {
@@ -376,6 +398,7 @@
       "deu"
     ],
     "name": "Belgium",
+    "numeric": "056",
     "status": "assigned"
   },
   {
@@ -393,6 +416,7 @@
       "fra"
     ],
     "name": "Burkina Faso",
+    "numeric": "854",
     "status": "assigned"
   },
   {
@@ -410,6 +434,7 @@
       "bul"
     ],
     "name": "Bulgaria",
+    "numeric": "100",
     "status": "assigned"
   },
   {
@@ -427,6 +452,7 @@
       "ara"
     ],
     "name": "Bahrain",
+    "numeric": "048",
     "status": "assigned"
   },
   {
@@ -444,6 +470,7 @@
       "fra"
     ],
     "name": "Burundi",
+    "numeric": "108",
     "status": "assigned"
   },
   {
@@ -461,6 +488,7 @@
       "fra"
     ],
     "name": "Benin",
+    "numeric": "204",
     "status": "assigned"
   },
   {
@@ -478,6 +506,7 @@
       "fra"
     ],
     "name": "Saint Barthélemy",
+    "numeric": "652",
     "status": "assigned"
   },
   {
@@ -495,6 +524,7 @@
       "eng"
     ],
     "name": "Bermuda",
+    "numeric": "060",
     "status": "assigned"
   },
   {
@@ -513,6 +543,7 @@
       "eng"
     ],
     "name": "Brunei Darussalam",
+    "numeric": "096",
     "status": "assigned"
   },
   {
@@ -533,6 +564,7 @@
       "que"
     ],
     "name": "Bolivia, Plurinational State Of",
+    "numeric": "068",
     "status": "assigned"
   },
   {
@@ -550,6 +582,7 @@
       "nld"
     ],
     "name": "Bonaire, Saint Eustatius And Saba",
+    "numeric": "535",
     "status": "assigned"
   },
   {
@@ -560,6 +593,7 @@
     "ioc": "",
     "languages": [],
     "name": "British Antarctic Territory",
+    "numeric": "535",
     "status": "deleted"
   },
   {
@@ -577,6 +611,7 @@
       "por"
     ],
     "name": "Brazil",
+    "numeric": "076",
     "status": "assigned"
   },
   {
@@ -594,6 +629,7 @@
       "eng"
     ],
     "name": "Bahamas",
+    "numeric": "044",
     "status": "assigned"
   },
   {
@@ -612,6 +648,7 @@
       "dzo"
     ],
     "name": "Bhutan",
+    "numeric": "064",
     "status": "assigned"
   },
   {
@@ -622,6 +659,7 @@
     "ioc": "",
     "languages": [],
     "name": "Burma",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -635,6 +673,7 @@
     "ioc": "",
     "languages": [],
     "name": "Bouvet Island",
+    "numeric": "074",
     "status": "assigned"
   },
   {
@@ -653,6 +692,7 @@
       "tsn"
     ],
     "name": "Botswana",
+    "numeric": "072",
     "status": "assigned"
   },
   {
@@ -671,6 +711,7 @@
       "rus"
     ],
     "name": "Belarus",
+    "numeric": "112",
     "status": "assigned"
   },
   {
@@ -681,6 +722,7 @@
     "ioc": "",
     "languages": [],
     "name": "Byelorussian SSR",
+    "numeric": "112",
     "status": "deleted"
   },
   {
@@ -698,6 +740,7 @@
       "eng"
     ],
     "name": "Belize",
+    "numeric": "084",
     "status": "assigned"
   },
   {
@@ -716,6 +759,7 @@
       "fra"
     ],
     "name": "Canada",
+    "numeric": "124",
     "status": "assigned"
   },
   {
@@ -733,6 +777,7 @@
       "eng"
     ],
     "name": "Cocos (Keeling) Islands",
+    "numeric": "166",
     "status": "assigned"
   },
   {
@@ -753,6 +798,7 @@
       "swa"
     ],
     "name": "Democratic Republic Of Congo",
+    "numeric": "180",
     "status": "assigned"
   },
   {
@@ -771,6 +817,7 @@
       "sag"
     ],
     "name": "Central African Republic",
+    "numeric": "140",
     "status": "assigned"
   },
   {
@@ -789,6 +836,7 @@
       "lin"
     ],
     "name": "Republic Of Congo",
+    "numeric": "178",
     "status": "assigned"
   },
   {
@@ -811,6 +859,7 @@
       "roh"
     ],
     "name": "Switzerland",
+    "numeric": "756",
     "status": "assigned"
   },
   {
@@ -828,6 +877,7 @@
       "fra"
     ],
     "name": "Côte d'Ivoire",
+    "numeric": "384",
     "status": "assigned"
   },
   {
@@ -846,6 +896,7 @@
       "mri"
     ],
     "name": "Cook Islands",
+    "numeric": "184",
     "status": "assigned"
   },
   {
@@ -864,6 +915,7 @@
       "spa"
     ],
     "name": "Chile",
+    "numeric": "152",
     "status": "assigned"
   },
   {
@@ -882,6 +934,7 @@
       "fra"
     ],
     "name": "Cameroon",
+    "numeric": "120",
     "status": "assigned"
   },
   {
@@ -899,6 +952,7 @@
       "zho"
     ],
     "name": "China",
+    "numeric": "156",
     "status": "assigned"
   },
   {
@@ -917,6 +971,7 @@
       "spa"
     ],
     "name": "Colombia",
+    "numeric": "170",
     "status": "assigned"
   },
   {
@@ -930,6 +985,7 @@
     "ioc": "",
     "languages": [],
     "name": "Clipperton Island",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -947,6 +1003,7 @@
       "spa"
     ],
     "name": "Costa Rica",
+    "numeric": "188",
     "status": "assigned"
   },
   {
@@ -957,6 +1014,7 @@
     "ioc": "",
     "languages": [],
     "name": "Czechoslovakia",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -967,6 +1025,7 @@
     "ioc": "",
     "languages": [],
     "name": "Serbia and Montenegro",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -977,6 +1036,7 @@
     "ioc": "",
     "languages": [],
     "name": "Canton and Enderbury Islands",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -995,6 +1055,7 @@
       "spa"
     ],
     "name": "Cuba",
+    "numeric": "192",
     "status": "assigned"
   },
   {
@@ -1012,6 +1073,7 @@
       "por"
     ],
     "name": "Cabo Verde",
+    "numeric": "132",
     "status": "assigned"
   },
   {
@@ -1029,6 +1091,7 @@
       "nld"
     ],
     "name": "Curacao",
+    "numeric": "531",
     "status": "assigned"
   },
   {
@@ -1046,6 +1109,7 @@
       "eng"
     ],
     "name": "Christmas Island",
+    "numeric": "162",
     "status": "assigned"
   },
   {
@@ -1064,6 +1128,7 @@
       "tur"
     ],
     "name": "Cyprus",
+    "numeric": "196",
     "status": "assigned"
   },
   {
@@ -1081,6 +1146,7 @@
       "ces"
     ],
     "name": "Czech Republic",
+    "numeric": "203",
     "status": "assigned"
   },
   {
@@ -1091,6 +1157,7 @@
     "ioc": "",
     "languages": [],
     "name": "German Democratic Republic",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -1108,6 +1175,7 @@
       "deu"
     ],
     "name": "Germany",
+    "numeric": "276",
     "status": "assigned"
   },
   {
@@ -1121,6 +1189,7 @@
     "ioc": "",
     "languages": [],
     "name": "Diego Garcia",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -1139,6 +1208,7 @@
       "fra"
     ],
     "name": "Djibouti",
+    "numeric": "262",
     "status": "assigned"
   },
   {
@@ -1156,6 +1226,7 @@
       "dan"
     ],
     "name": "Denmark",
+    "numeric": "208",
     "status": "assigned"
   },
   {
@@ -1173,6 +1244,7 @@
       "eng"
     ],
     "name": "Dominica",
+    "numeric": "212",
     "status": "assigned"
   },
   {
@@ -1192,6 +1264,7 @@
       "spa"
     ],
     "name": "Dominican Republic",
+    "numeric": "214",
     "status": "assigned"
   },
   {
@@ -1202,6 +1275,7 @@
     "ioc": "",
     "languages": [],
     "name": "Dahomey",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -1219,6 +1293,7 @@
       "ara"
     ],
     "name": "Algeria",
+    "numeric": "012",
     "status": "assigned"
   },
   {
@@ -1232,6 +1307,7 @@
     "ioc": "",
     "languages": [],
     "name": "Ceuta, Mulilla",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -1250,6 +1326,7 @@
       "que"
     ],
     "name": "Ecuador",
+    "numeric": "218",
     "status": "assigned"
   },
   {
@@ -1267,6 +1344,7 @@
       "est"
     ],
     "name": "Estonia",
+    "numeric": "233",
     "status": "assigned"
   },
   {
@@ -1284,6 +1362,7 @@
       "ara"
     ],
     "name": "Egypt",
+    "numeric": "818",
     "status": "assigned"
   },
   {
@@ -1299,6 +1378,7 @@
     "ioc": "",
     "languages": [],
     "name": "Western Sahara",
+    "numeric": "732",
     "status": "assigned"
   },
   {
@@ -1318,6 +1398,7 @@
       "tir"
     ],
     "name": "Eritrea",
+    "numeric": "232",
     "status": "assigned"
   },
   {
@@ -1335,6 +1416,7 @@
       "spa"
     ],
     "name": "Spain",
+    "numeric": "724",
     "status": "assigned"
   },
   {
@@ -1352,6 +1434,7 @@
       "amh"
     ],
     "name": "Ethiopia",
+    "numeric": "231",
     "status": "assigned"
   },
   {
@@ -1367,6 +1450,7 @@
     "ioc": "",
     "languages": [],
     "name": "European Union",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -1385,6 +1469,7 @@
       "swe"
     ],
     "name": "Finland",
+    "numeric": "246",
     "status": "assigned"
   },
   {
@@ -1403,6 +1488,7 @@
       "fij"
     ],
     "name": "Fiji",
+    "numeric": "242",
     "status": "assigned"
   },
   {
@@ -1420,6 +1506,7 @@
       "eng"
     ],
     "name": "Falkland Islands",
+    "numeric": "238",
     "status": "assigned"
   },
   {
@@ -1437,6 +1524,7 @@
       "eng"
     ],
     "name": "Micronesia, Federated States Of",
+    "numeric": "583",
     "status": "assigned"
   },
   {
@@ -1455,6 +1543,7 @@
       "dan"
     ],
     "name": "Faroe Islands",
+    "numeric": "234",
     "status": "assigned"
   },
   {
@@ -1465,6 +1554,7 @@
     "ioc": "",
     "languages": [],
     "name": "French Southern and Antarctic Territories",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -1482,6 +1572,7 @@
       "fra"
     ],
     "name": "France",
+    "numeric": "250",
     "status": "assigned"
   },
   {
@@ -1499,6 +1590,7 @@
       "fra"
     ],
     "name": "France, Metropolitan",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -1516,6 +1608,7 @@
       "fra"
     ],
     "name": "Gabon",
+    "numeric": "266",
     "status": "assigned"
   },
   {
@@ -1537,6 +1630,7 @@
       "cym"
     ],
     "name": "United Kingdom",
+    "numeric": "826",
     "status": "assigned"
   },
   {
@@ -1554,6 +1648,7 @@
       "eng"
     ],
     "name": "Grenada",
+    "numeric": "308",
     "status": "assigned"
   },
   {
@@ -1571,6 +1666,7 @@
       "kat"
     ],
     "name": "Georgia",
+    "numeric": "268",
     "status": "assigned"
   },
   {
@@ -1581,6 +1677,7 @@
     "ioc": "",
     "languages": [],
     "name": "Gilbert and Ellice Islands",
+    "numeric": "268",
     "status": "deleted"
   },
   {
@@ -1598,6 +1695,7 @@
       "fra"
     ],
     "name": "French Guiana",
+    "numeric": "254",
     "status": "assigned"
   },
   {
@@ -1615,6 +1713,7 @@
       "fra"
     ],
     "name": "Guernsey",
+    "numeric": "831",
     "status": "assigned"
   },
   {
@@ -1632,6 +1731,7 @@
       "eng"
     ],
     "name": "Ghana",
+    "numeric": "288",
     "status": "assigned"
   },
   {
@@ -1649,6 +1749,7 @@
       "eng"
     ],
     "name": "Gibraltar",
+    "numeric": "292",
     "status": "assigned"
   },
   {
@@ -1666,6 +1767,7 @@
       "kal"
     ],
     "name": "Greenland",
+    "numeric": "304",
     "status": "assigned"
   },
   {
@@ -1683,6 +1785,7 @@
       "eng"
     ],
     "name": "Gambia",
+    "numeric": "270",
     "status": "assigned"
   },
   {
@@ -1700,6 +1803,7 @@
       "fra"
     ],
     "name": "Guinea",
+    "numeric": "324",
     "status": "assigned"
   },
   {
@@ -1717,6 +1821,7 @@
       "fra"
     ],
     "name": "Guadeloupe",
+    "numeric": "312",
     "status": "assigned"
   },
   {
@@ -1736,6 +1841,7 @@
       "por"
     ],
     "name": "Equatorial Guinea",
+    "numeric": "226",
     "status": "assigned"
   },
   {
@@ -1753,6 +1859,7 @@
       "ell"
     ],
     "name": "Greece",
+    "numeric": "300",
     "status": "assigned"
   },
   {
@@ -1768,6 +1875,7 @@
       "eng"
     ],
     "name": "South Georgia And The South Sandwich Islands",
+    "numeric": "239",
     "status": "assigned"
   },
   {
@@ -1785,6 +1893,7 @@
       "spa"
     ],
     "name": "Guatemala",
+    "numeric": "320",
     "status": "assigned"
   },
   {
@@ -1802,6 +1911,7 @@
       "eng"
     ],
     "name": "Guam",
+    "numeric": "316",
     "status": "assigned"
   },
   {
@@ -1819,6 +1929,7 @@
       "por"
     ],
     "name": "Guinea-bissau",
+    "numeric": "624",
     "status": "assigned"
   },
   {
@@ -1836,6 +1947,7 @@
       "eng"
     ],
     "name": "Guyana",
+    "numeric": "328",
     "status": "assigned"
   },
   {
@@ -1854,6 +1966,7 @@
       "eng"
     ],
     "name": "Hong Kong",
+    "numeric": "344",
     "status": "assigned"
   },
   {
@@ -1867,6 +1980,7 @@
     "ioc": "",
     "languages": [],
     "name": "Heard Island And McDonald Islands",
+    "numeric": "334",
     "status": "assigned"
   },
   {
@@ -1884,6 +1998,7 @@
       "spa"
     ],
     "name": "Honduras",
+    "numeric": "340",
     "status": "assigned"
   },
   {
@@ -1901,6 +2016,7 @@
       "hrv"
     ],
     "name": "Croatia",
+    "numeric": "191",
     "status": "assigned"
   },
   {
@@ -1920,6 +2036,7 @@
       "hat"
     ],
     "name": "Haiti",
+    "numeric": "332",
     "status": "assigned"
   },
   {
@@ -1937,6 +2054,7 @@
       "hun"
     ],
     "name": "Hungary",
+    "numeric": "348",
     "status": "assigned"
   },
   {
@@ -1947,6 +2065,7 @@
     "ioc": "",
     "languages": [],
     "name": "Upper Volta",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -1960,6 +2079,7 @@
     "ioc": "",
     "languages": [],
     "name": "Canary Islands",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -1977,6 +2097,7 @@
       "ind"
     ],
     "name": "Indonesia",
+    "numeric": "360",
     "status": "assigned"
   },
   {
@@ -1995,6 +2116,7 @@
       "gle"
     ],
     "name": "Ireland",
+    "numeric": "372",
     "status": "assigned"
   },
   {
@@ -2014,6 +2136,7 @@
       "eng"
     ],
     "name": "Israel",
+    "numeric": "376",
     "status": "assigned"
   },
   {
@@ -2032,6 +2155,7 @@
       "glv"
     ],
     "name": "Isle Of Man",
+    "numeric": "833",
     "status": "assigned"
   },
   {
@@ -2050,6 +2174,7 @@
       "hin"
     ],
     "name": "India",
+    "numeric": "356",
     "status": "assigned"
   },
   {
@@ -2067,6 +2192,7 @@
       "eng"
     ],
     "name": "British Indian Ocean Territory",
+    "numeric": "086",
     "status": "assigned"
   },
   {
@@ -2085,6 +2211,7 @@
       "kur"
     ],
     "name": "Iraq",
+    "numeric": "368",
     "status": "assigned"
   },
   {
@@ -2102,6 +2229,7 @@
       "fas"
     ],
     "name": "Iran, Islamic Republic Of",
+    "numeric": "364",
     "status": "assigned"
   },
   {
@@ -2119,6 +2247,7 @@
       "isl"
     ],
     "name": "Iceland",
+    "numeric": "352",
     "status": "assigned"
   },
   {
@@ -2136,6 +2265,7 @@
       "ita"
     ],
     "name": "Italy",
+    "numeric": "380",
     "status": "assigned"
   },
   {
@@ -2154,6 +2284,7 @@
       "fra"
     ],
     "name": "Jersey",
+    "numeric": "832",
     "status": "assigned"
   },
   {
@@ -2171,6 +2302,7 @@
       "eng"
     ],
     "name": "Jamaica",
+    "numeric": "388",
     "status": "assigned"
   },
   {
@@ -2188,6 +2320,7 @@
       "ara"
     ],
     "name": "Jordan",
+    "numeric": "400",
     "status": "assigned"
   },
   {
@@ -2205,6 +2338,7 @@
       "jpn"
     ],
     "name": "Japan",
+    "numeric": "392",
     "status": "assigned"
   },
   {
@@ -2215,6 +2349,7 @@
     "ioc": "",
     "languages": [],
     "name": "Johnston Island",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -2233,6 +2368,7 @@
       "swa"
     ],
     "name": "Kenya",
+    "numeric": "404",
     "status": "assigned"
   },
   {
@@ -2250,6 +2386,7 @@
       "rus"
     ],
     "name": "Kyrgyzstan",
+    "numeric": "417",
     "status": "assigned"
   },
   {
@@ -2267,6 +2404,7 @@
       "khm"
     ],
     "name": "Cambodia",
+    "numeric": "116",
     "status": "assigned"
   },
   {
@@ -2284,6 +2422,7 @@
       "eng"
     ],
     "name": "Kiribati",
+    "numeric": "296",
     "status": "assigned"
   },
   {
@@ -2302,6 +2441,7 @@
       "fra"
     ],
     "name": "Comoros",
+    "numeric": "174",
     "status": "assigned"
   },
   {
@@ -2319,6 +2459,7 @@
       "eng"
     ],
     "name": "Saint Kitts And Nevis",
+    "numeric": "659",
     "status": "assigned"
   },
   {
@@ -2336,6 +2477,7 @@
       "kor"
     ],
     "name": "Korea, Democratic People's Republic Of",
+    "numeric": "408",
     "status": "assigned"
   },
   {
@@ -2353,6 +2495,7 @@
       "kor"
     ],
     "name": "Korea, Republic Of",
+    "numeric": "410",
     "status": "assigned"
   },
   {
@@ -2370,6 +2513,7 @@
       "ara"
     ],
     "name": "Kuwait",
+    "numeric": "414",
     "status": "assigned"
   },
   {
@@ -2387,6 +2531,7 @@
       "eng"
     ],
     "name": "Cayman Islands",
+    "numeric": "136",
     "status": "assigned"
   },
   {
@@ -2407,6 +2552,7 @@
       "rus"
     ],
     "name": "Kazakhstan",
+    "numeric": "398",
     "status": "assigned"
   },
   {
@@ -2424,6 +2570,7 @@
       "lao"
     ],
     "name": "Lao People's Democratic Republic",
+    "numeric": "418",
     "status": "assigned"
   },
   {
@@ -2442,6 +2589,7 @@
       "hye"
     ],
     "name": "Lebanon",
+    "numeric": "422",
     "status": "assigned"
   },
   {
@@ -2459,6 +2607,7 @@
       "eng"
     ],
     "name": "Saint Lucia",
+    "numeric": "662",
     "status": "assigned"
   },
   {
@@ -2476,6 +2625,7 @@
       "deu"
     ],
     "name": "Liechtenstein",
+    "numeric": "438",
     "status": "assigned"
   },
   {
@@ -2494,6 +2644,7 @@
       "tam"
     ],
     "name": "Sri Lanka",
+    "numeric": "144",
     "status": "assigned"
   },
   {
@@ -2511,6 +2662,7 @@
       "eng"
     ],
     "name": "Liberia",
+    "numeric": "430",
     "status": "assigned"
   },
   {
@@ -2530,6 +2682,7 @@
       "sot"
     ],
     "name": "Lesotho",
+    "numeric": "426",
     "status": "assigned"
   },
   {
@@ -2547,6 +2700,7 @@
       "lit"
     ],
     "name": "Lithuania",
+    "numeric": "440",
     "status": "assigned"
   },
   {
@@ -2566,6 +2720,7 @@
       "ltz"
     ],
     "name": "Luxembourg",
+    "numeric": "442",
     "status": "assigned"
   },
   {
@@ -2583,6 +2738,7 @@
       "lav"
     ],
     "name": "Latvia",
+    "numeric": "428",
     "status": "assigned"
   },
   {
@@ -2600,6 +2756,7 @@
       "ara"
     ],
     "name": "Libya",
+    "numeric": "434",
     "status": "assigned"
   },
   {
@@ -2617,6 +2774,7 @@
       "ara"
     ],
     "name": "Morocco",
+    "numeric": "504",
     "status": "assigned"
   },
   {
@@ -2634,6 +2792,7 @@
       "fra"
     ],
     "name": "Monaco",
+    "numeric": "492",
     "status": "assigned"
   },
   {
@@ -2651,6 +2810,7 @@
       "ron"
     ],
     "name": "Moldova",
+    "numeric": "498",
     "status": "assigned"
   },
   {
@@ -2668,6 +2828,7 @@
       "mot"
     ],
     "name": "Montenegro",
+    "numeric": "499",
     "status": "assigned"
   },
   {
@@ -2685,6 +2846,7 @@
       "fra"
     ],
     "name": "Saint Martin",
+    "numeric": "663",
     "status": "assigned"
   },
   {
@@ -2703,6 +2865,7 @@
       "mlg"
     ],
     "name": "Madagascar",
+    "numeric": "450",
     "status": "assigned"
   },
   {
@@ -2721,6 +2884,7 @@
       "mah"
     ],
     "name": "Marshall Islands",
+    "numeric": "584",
     "status": "assigned"
   },
   {
@@ -2731,6 +2895,7 @@
     "ioc": "",
     "languages": [],
     "name": "Midway Islands",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -2748,6 +2913,7 @@
       "mkd"
     ],
     "name": "Macedonia, The Former Yugoslav Republic Of",
+    "numeric": "807",
     "status": "assigned"
   },
   {
@@ -2765,6 +2931,7 @@
       "fra"
     ],
     "name": "Mali",
+    "numeric": "466",
     "status": "assigned"
   },
   {
@@ -2782,6 +2949,7 @@
       "mya"
     ],
     "name": "Myanmar",
+    "numeric": "104",
     "status": "assigned"
   },
   {
@@ -2799,6 +2967,7 @@
       "mon"
     ],
     "name": "Mongolia",
+    "numeric": "496",
     "status": "assigned"
   },
   {
@@ -2817,6 +2986,7 @@
       "por"
     ],
     "name": "Macao",
+    "numeric": "446",
     "status": "assigned"
   },
   {
@@ -2834,6 +3004,7 @@
       "eng"
     ],
     "name": "Northern Mariana Islands",
+    "numeric": "580",
     "status": "assigned"
   },
   {
@@ -2849,6 +3020,7 @@
     "ioc": "",
     "languages": [],
     "name": "Martinique",
+    "numeric": "474",
     "status": "assigned"
   },
   {
@@ -2867,6 +3039,7 @@
       "fra"
     ],
     "name": "Mauritania",
+    "numeric": "478",
     "status": "assigned"
   },
   {
@@ -2882,6 +3055,7 @@
     "ioc": "",
     "languages": [],
     "name": "Montserrat",
+    "numeric": "500",
     "status": "assigned"
   },
   {
@@ -2900,6 +3074,7 @@
       "eng"
     ],
     "name": "Malta",
+    "numeric": "470",
     "status": "assigned"
   },
   {
@@ -2918,6 +3093,7 @@
       "fra"
     ],
     "name": "Mauritius",
+    "numeric": "480",
     "status": "assigned"
   },
   {
@@ -2935,6 +3111,7 @@
       "div"
     ],
     "name": "Maldives",
+    "numeric": "462",
     "status": "assigned"
   },
   {
@@ -2953,6 +3130,7 @@
       "nya"
     ],
     "name": "Malawi",
+    "numeric": "454",
     "status": "assigned"
   },
   {
@@ -2971,6 +3149,7 @@
       "spa"
     ],
     "name": "Mexico",
+    "numeric": "484",
     "status": "assigned"
   },
   {
@@ -2989,6 +3168,7 @@
       "eng"
     ],
     "name": "Malaysia",
+    "numeric": "458",
     "status": "assigned"
   },
   {
@@ -3006,6 +3186,7 @@
       "por"
     ],
     "name": "Mozambique",
+    "numeric": "508",
     "status": "assigned"
   },
   {
@@ -3024,6 +3205,7 @@
       "eng"
     ],
     "name": "Namibia",
+    "numeric": "516",
     "status": "assigned"
   },
   {
@@ -3041,6 +3223,7 @@
       "fra"
     ],
     "name": "New Caledonia",
+    "numeric": "540",
     "status": "assigned"
   },
   {
@@ -3058,6 +3241,7 @@
       "fra"
     ],
     "name": "Niger",
+    "numeric": "562",
     "status": "assigned"
   },
   {
@@ -3075,6 +3259,7 @@
       "eng"
     ],
     "name": "Norfolk Island",
+    "numeric": "574",
     "status": "assigned"
   },
   {
@@ -3092,6 +3277,7 @@
       "eng"
     ],
     "name": "Nigeria",
+    "numeric": "566",
     "status": "assigned"
   },
   {
@@ -3102,6 +3288,7 @@
     "ioc": "",
     "languages": [],
     "name": "New Hebrides",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -3119,6 +3306,7 @@
       "spa"
     ],
     "name": "Nicaragua",
+    "numeric": "558",
     "status": "assigned"
   },
   {
@@ -3136,6 +3324,7 @@
       "nld"
     ],
     "name": "Netherlands",
+    "numeric": "528",
     "status": "assigned"
   },
   {
@@ -3153,6 +3342,7 @@
       "nor"
     ],
     "name": "Norway",
+    "numeric": "578",
     "status": "assigned"
   },
   {
@@ -3170,6 +3360,7 @@
       "nep"
     ],
     "name": "Nepal",
+    "numeric": "524",
     "status": "assigned"
   },
   {
@@ -3180,6 +3371,7 @@
     "ioc": "",
     "languages": [],
     "name": "Dronning Maud Land",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -3198,6 +3390,7 @@
       "nau"
     ],
     "name": "Nauru",
+    "numeric": "520",
     "status": "assigned"
   },
   {
@@ -3208,6 +3401,7 @@
     "ioc": "",
     "languages": [],
     "name": "Neutral Zone",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -3225,6 +3419,7 @@
       "eng"
     ],
     "name": "Niue",
+    "numeric": "570",
     "status": "assigned"
   },
   {
@@ -3242,6 +3437,7 @@
       "eng"
     ],
     "name": "New Zealand",
+    "numeric": "554",
     "status": "assigned"
   },
   {
@@ -3259,6 +3455,7 @@
       "ara"
     ],
     "name": "Oman",
+    "numeric": "512",
     "status": "assigned"
   },
   {
@@ -3277,6 +3474,7 @@
       "spa"
     ],
     "name": "Panama",
+    "numeric": "591",
     "status": "assigned"
   },
   {
@@ -3287,6 +3485,7 @@
     "ioc": "",
     "languages": [],
     "name": "Pacific Islands, Trust Territory of the",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -3306,6 +3505,7 @@
       "que"
     ],
     "name": "Peru",
+    "numeric": "604",
     "status": "assigned"
   },
   {
@@ -3323,6 +3523,7 @@
       "fra"
     ],
     "name": "French Polynesia",
+    "numeric": "258",
     "status": "assigned"
   },
   {
@@ -3340,6 +3541,7 @@
       "eng"
     ],
     "name": "Papua New Guinea",
+    "numeric": "598",
     "status": "assigned"
   },
   {
@@ -3357,6 +3559,7 @@
       "eng"
     ],
     "name": "Philippines",
+    "numeric": "608",
     "status": "assigned"
   },
   {
@@ -3375,6 +3578,7 @@
       "eng"
     ],
     "name": "Pakistan",
+    "numeric": "586",
     "status": "assigned"
   },
   {
@@ -3392,6 +3596,7 @@
       "pol"
     ],
     "name": "Poland",
+    "numeric": "616",
     "status": "assigned"
   },
   {
@@ -3409,6 +3614,7 @@
       "eng"
     ],
     "name": "Saint Pierre And Miquelon",
+    "numeric": "666",
     "status": "assigned"
   },
   {
@@ -3426,6 +3632,7 @@
       "eng"
     ],
     "name": "Pitcairn",
+    "numeric": "612",
     "status": "assigned"
   },
   {
@@ -3445,6 +3652,7 @@
       "eng"
     ],
     "name": "Puerto Rico",
+    "numeric": "630",
     "status": "assigned"
   },
   {
@@ -3464,6 +3672,7 @@
       "ara"
     ],
     "name": "Palestinian Territory, Occupied",
+    "numeric": "275",
     "status": "assigned"
   },
   {
@@ -3481,6 +3690,7 @@
       "por"
     ],
     "name": "Portugal",
+    "numeric": "620",
     "status": "assigned"
   },
   {
@@ -3491,6 +3701,7 @@
     "ioc": "",
     "languages": [],
     "name": "U.S. Miscellaneous Pacific Islands",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -3508,6 +3719,7 @@
       "eng"
     ],
     "name": "Palau",
+    "numeric": "585",
     "status": "assigned"
   },
   {
@@ -3525,6 +3737,7 @@
       "spa"
     ],
     "name": "Paraguay",
+    "numeric": "600",
     "status": "assigned"
   },
   {
@@ -3535,6 +3748,7 @@
     "ioc": "",
     "languages": [],
     "name": "Panama Canal Zone",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -3552,6 +3766,7 @@
       "ara"
     ],
     "name": "Qatar",
+    "numeric": "634",
     "status": "assigned"
   },
   {
@@ -3569,6 +3784,7 @@
       "fra"
     ],
     "name": "Reunion",
+    "numeric": "638",
     "status": "assigned"
   },
   {
@@ -3579,6 +3795,7 @@
     "ioc": "",
     "languages": [],
     "name": "Southern Rhodesia",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -3596,6 +3813,7 @@
       "ron"
     ],
     "name": "Romania",
+    "numeric": "642",
     "status": "assigned"
   },
   {
@@ -3613,6 +3831,7 @@
       "srp"
     ],
     "name": "Serbia",
+    "numeric": "688",
     "status": "assigned"
   },
   {
@@ -3633,6 +3852,7 @@
       "rus"
     ],
     "name": "Russian Federation",
+    "numeric": "643",
     "status": "assigned"
   },
   {
@@ -3652,6 +3872,7 @@
       "kin"
     ],
     "name": "Rwanda",
+    "numeric": "646",
     "status": "assigned"
   },
   {
@@ -3669,6 +3890,7 @@
       "ara"
     ],
     "name": "Saudi Arabia",
+    "numeric": "682",
     "status": "assigned"
   },
   {
@@ -3686,6 +3908,7 @@
       "eng"
     ],
     "name": "Solomon Islands",
+    "numeric": "090",
     "status": "assigned"
   },
   {
@@ -3704,6 +3927,7 @@
       "fra"
     ],
     "name": "Seychelles",
+    "numeric": "690",
     "status": "assigned"
   },
   {
@@ -3722,6 +3946,7 @@
       "eng"
     ],
     "name": "Sudan",
+    "numeric": "729",
     "status": "assigned"
   },
   {
@@ -3739,6 +3964,7 @@
       "swe"
     ],
     "name": "Sweden",
+    "numeric": "752",
     "status": "assigned"
   },
   {
@@ -3759,6 +3985,7 @@
       "tam"
     ],
     "name": "Singapore",
+    "numeric": "702",
     "status": "assigned"
   },
   {
@@ -3776,6 +4003,7 @@
       "eng"
     ],
     "name": "Saint Helena, Ascension And Tristan Da Cunha",
+    "numeric": "654",
     "status": "assigned"
   },
   {
@@ -3793,6 +4021,7 @@
       "slv"
     ],
     "name": "Slovenia",
+    "numeric": "705",
     "status": "assigned"
   },
   {
@@ -3808,6 +4037,7 @@
     "ioc": "",
     "languages": [],
     "name": "Svalbard And Jan Mayen",
+    "numeric": "744",
     "status": "assigned"
   },
   {
@@ -3825,6 +4055,7 @@
       "slk"
     ],
     "name": "Slovakia",
+    "numeric": "703",
     "status": "assigned"
   },
   {
@@ -3835,6 +4066,7 @@
     "ioc": "",
     "languages": [],
     "name": "Sikkim",
+    "numeric": "703",
     "status": "deleted"
   },
   {
@@ -3852,6 +4084,7 @@
       "eng"
     ],
     "name": "Sierra Leone",
+    "numeric": "694",
     "status": "assigned"
   },
   {
@@ -3869,6 +4102,7 @@
       "ita"
     ],
     "name": "San Marino",
+    "numeric": "674",
     "status": "assigned"
   },
   {
@@ -3886,6 +4120,7 @@
       "fra"
     ],
     "name": "Senegal",
+    "numeric": "686",
     "status": "assigned"
   },
   {
@@ -3903,6 +4138,7 @@
       "som"
     ],
     "name": "Somalia",
+    "numeric": "706",
     "status": "assigned"
   },
   {
@@ -3920,6 +4156,7 @@
       "nld"
     ],
     "name": "Suriname",
+    "numeric": "740",
     "status": "assigned"
   },
   {
@@ -3937,6 +4174,7 @@
       "eng"
     ],
     "name": "South Sudan",
+    "numeric": "728",
     "status": "assigned"
   },
   {
@@ -3954,6 +4192,7 @@
       "por"
     ],
     "name": "Sao Tome and Principe",
+    "numeric": "678",
     "status": "assigned"
   },
   {
@@ -3969,6 +4208,7 @@
       "rus"
     ],
     "name": "USSR",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -3986,6 +4226,7 @@
       "spa"
     ],
     "name": "El Salvador",
+    "numeric": "222",
     "status": "assigned"
   },
   {
@@ -4003,6 +4244,7 @@
       "nld"
     ],
     "name": "Sint Maarten",
+    "numeric": "534",
     "status": "assigned"
   },
   {
@@ -4020,6 +4262,7 @@
       "ara"
     ],
     "name": "Syrian Arab Republic",
+    "numeric": "760",
     "status": "assigned"
   },
   {
@@ -4038,6 +4281,7 @@
       "ssw"
     ],
     "name": "Swaziland",
+    "numeric": "748",
     "status": "assigned"
   },
   {
@@ -4053,6 +4297,7 @@
     "ioc": "",
     "languages": [],
     "name": "Tristan de Cunha",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -4070,6 +4315,7 @@
       "eng"
     ],
     "name": "Turks And Caicos Islands",
+    "numeric": "796",
     "status": "assigned"
   },
   {
@@ -4088,6 +4334,7 @@
       "fra"
     ],
     "name": "Chad",
+    "numeric": "148",
     "status": "assigned"
   },
   {
@@ -4103,6 +4350,7 @@
       "fra"
     ],
     "name": "French Southern Territories",
+    "numeric": "260",
     "status": "assigned"
   },
   {
@@ -4120,6 +4368,7 @@
       "fra"
     ],
     "name": "Togo",
+    "numeric": "768",
     "status": "assigned"
   },
   {
@@ -4137,6 +4386,7 @@
       "tha"
     ],
     "name": "Thailand",
+    "numeric": "764",
     "status": "assigned"
   },
   {
@@ -4155,6 +4405,7 @@
       "rus"
     ],
     "name": "Tajikistan",
+    "numeric": "762",
     "status": "assigned"
   },
   {
@@ -4172,6 +4423,7 @@
       "eng"
     ],
     "name": "Tokelau",
+    "numeric": "772",
     "status": "assigned"
   },
   {
@@ -4189,6 +4441,7 @@
       "por"
     ],
     "name": "Timor-Leste, Democratic Republic of",
+    "numeric": "626",
     "status": "assigned"
   },
   {
@@ -4207,6 +4460,7 @@
       "rus"
     ],
     "name": "Turkmenistan",
+    "numeric": "795",
     "status": "assigned"
   },
   {
@@ -4224,6 +4478,7 @@
       "ara"
     ],
     "name": "Tunisia",
+    "numeric": "788",
     "status": "assigned"
   },
   {
@@ -4241,6 +4496,7 @@
       "eng"
     ],
     "name": "Tonga",
+    "numeric": "776",
     "status": "assigned"
   },
   {
@@ -4251,6 +4507,7 @@
     "ioc": "",
     "languages": [],
     "name": "East Timor",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -4268,6 +4525,7 @@
       "tur"
     ],
     "name": "Turkey",
+    "numeric": "792",
     "status": "assigned"
   },
   {
@@ -4285,6 +4543,7 @@
       "eng"
     ],
     "name": "Trinidad And Tobago",
+    "numeric": "780",
     "status": "assigned"
   },
   {
@@ -4302,6 +4561,7 @@
       "eng"
     ],
     "name": "Tuvalu",
+    "numeric": "798",
     "status": "assigned"
   },
   {
@@ -4319,6 +4579,7 @@
       "zho"
     ],
     "name": "Taiwan",
+    "numeric": "158",
     "status": "assigned"
   },
   {
@@ -4337,6 +4598,7 @@
       "eng"
     ],
     "name": "Tanzania, United Republic Of",
+    "numeric": "834",
     "status": "assigned"
   },
   {
@@ -4355,6 +4617,7 @@
       "rus"
     ],
     "name": "Ukraine",
+    "numeric": "804",
     "status": "assigned"
   },
   {
@@ -4373,6 +4636,7 @@
       "swa"
     ],
     "name": "Uganda",
+    "numeric": "800",
     "status": "assigned"
   },
   {
@@ -4392,6 +4656,7 @@
       "cym"
     ],
     "name": "United Kingdom",
+    "numeric": "",
     "status": "reserved"
   },
   {
@@ -4409,6 +4674,7 @@
       "eng"
     ],
     "name": "United States Minor Outlying Islands",
+    "numeric": "581",
     "status": "assigned"
   },
   {
@@ -4426,6 +4692,7 @@
       "eng"
     ],
     "name": "United States",
+    "numeric": "840",
     "status": "assigned"
   },
   {
@@ -4444,6 +4711,7 @@
       "spa"
     ],
     "name": "Uruguay",
+    "numeric": "858",
     "status": "assigned"
   },
   {
@@ -4462,6 +4730,7 @@
       "rus"
     ],
     "name": "Uzbekistan",
+    "numeric": "860",
     "status": "assigned"
   },
   {
@@ -4480,6 +4749,7 @@
       "ita"
     ],
     "name": "Vatican City State",
+    "numeric": "336",
     "status": "assigned"
   },
   {
@@ -4497,6 +4767,7 @@
       "eng"
     ],
     "name": "Saint Vincent And The Grenadines",
+    "numeric": "670",
     "status": "assigned"
   },
   {
@@ -4507,6 +4778,7 @@
     "ioc": "",
     "languages": [],
     "name": "Viet-Nam, Democratic Republic of",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -4524,6 +4796,7 @@
       "spa"
     ],
     "name": "Venezuela, Bolivarian Republic Of",
+    "numeric": "862",
     "status": "assigned"
   },
   {
@@ -4541,6 +4814,7 @@
       "eng"
     ],
     "name": "Virgin Islands (British)",
+    "numeric": "092",
     "status": "assigned"
   },
   {
@@ -4558,6 +4832,7 @@
       "eng"
     ],
     "name": "Virgin Islands (US)",
+    "numeric": "850",
     "status": "assigned"
   },
   {
@@ -4575,6 +4850,7 @@
       "vie"
     ],
     "name": "Viet Nam",
+    "numeric": "704",
     "status": "assigned"
   },
   {
@@ -4594,6 +4870,7 @@
       "fra"
     ],
     "name": "Vanuatu",
+    "numeric": "548",
     "status": "assigned"
   },
   {
@@ -4611,6 +4888,7 @@
       "fra"
     ],
     "name": "Wallis And Futuna",
+    "numeric": "876",
     "status": "assigned"
   },
   {
@@ -4621,6 +4899,7 @@
     "ioc": "",
     "languages": [],
     "name": "Wake Island",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -4639,6 +4918,7 @@
       "smo"
     ],
     "name": "Samoa",
+    "numeric": "882",
     "status": "assigned"
   },
   {
@@ -4660,6 +4940,7 @@
       "rom"
     ],
     "name": "Kosovo",
+    "numeric": "",
     "status": "user assigned"
   },
   {
@@ -4670,6 +4951,7 @@
     "ioc": "",
     "languages": [],
     "name": "Yemen, Democratic",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -4687,6 +4969,7 @@
       "ara"
     ],
     "name": "Yemen",
+    "numeric": "887",
     "status": "assigned"
   },
   {
@@ -4704,6 +4987,7 @@
       "fra"
     ],
     "name": "Mayotte",
+    "numeric": "175",
     "status": "assigned"
   },
   {
@@ -4714,6 +4998,7 @@
     "ioc": "",
     "languages": [],
     "name": "Yugoslavia",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -4738,6 +5023,7 @@
       "zul"
     ],
     "name": "South Africa",
+    "numeric": "710",
     "status": "assigned"
   },
   {
@@ -4755,6 +5041,7 @@
       "eng"
     ],
     "name": "Zambia",
+    "numeric": "894",
     "status": "assigned"
   },
   {
@@ -4765,6 +5052,7 @@
     "ioc": "",
     "languages": [],
     "name": "Zaire",
+    "numeric": "",
     "status": "deleted"
   },
   {
@@ -4788,6 +5076,7 @@
       "nde"
     ],
     "name": "Zimbabwe",
+    "numeric": "716",
     "status": "assigned"
   }
 ]

--- a/data/deleted_countries.csv
+++ b/data/deleted_countries.csv
@@ -1,30 +1,30 @@
-name,alpha2,alpha3,ccTLD,countryCallingCodes,currencies,ioc,languages,status
-British Antarctic Territory,BQ,ATB,,,,,,deleted
-Burma,BU,BUR,,,,,,deleted
-Byelorussian SSR,BY,BYS,,,,,,deleted
-Canton and Enderbury Islands,CT,CTE,,,,,,deleted
-Czechoslovakia,CS,CSK,,,,,,deleted
-Dahomey,DY,DHY,,,,,,deleted
-Dronning Maud Land,NQ,ATN,,,,,,deleted
-East Timor,TP,TMP,,,,,,deleted
-French Afar and Issas,AI,AFI,,,,,,deleted
-French Southern and Antarctic Territories,FQ,ATF,,,,,,deleted
-German Democratic Republic,DD,DDR,,,,,,deleted
-Gilbert and Ellice Islands,GE,GEL,,,,,,deleted
-Johnston Island,JT,JTN,,,,,,deleted
-Midway Islands,MI,MID,,,,,,deleted
-Netherlands Antilles,AN,ANT,,,,,,deleted
-Neutral Zone,NT,NTZ,,,,,,deleted
-New Hebrides,NH,NHB,,,,,,deleted
-"Pacific Islands, Trust Territory of the",PC,PCI,,,,,,deleted
-Panama Canal Zone,PZ,PCZ,,,,,,deleted
-Serbia and Montenegro,CS,SCG,,,,,,deleted
-Sikkim,SK,SKM,,,,,,deleted
-Southern Rhodesia,RH,RHO,,,,,,deleted
-U.S. Miscellaneous Pacific Islands,PU,PUS,,,,,,deleted
-Upper Volta,HV,HVO,,,,,,deleted
-"Viet-Nam, Democratic Republic of",VD,VDR,,,,,,deleted
-Wake Island,WK,WAK,,,,,,deleted
-"Yemen, Democratic",YD,YMD,,,,,,deleted
-Yugoslavia,YU,YUG,,,,,,deleted
-Zaire,ZR,ZAR,,,,,,deleted
+name,alpha2,alpha3,ccTLD,countryCallingCodes,currencies,ioc,languages,status,numeric
+British Antarctic Territory,BQ,ATB,,,,,,deleted,535
+Burma,BU,BUR,,,,,,deleted,
+Byelorussian SSR,BY,BYS,,,,,,deleted,112
+Canton and Enderbury Islands,CT,CTE,,,,,,deleted,
+Czechoslovakia,CS,CSK,,,,,,deleted,
+Dahomey,DY,DHY,,,,,,deleted,
+Dronning Maud Land,NQ,ATN,,,,,,deleted,
+East Timor,TP,TMP,,,,,,deleted,
+French Afar and Issas,AI,AFI,,,,,,deleted,660
+French Southern and Antarctic Territories,FQ,ATF,,,,,,deleted,
+German Democratic Republic,DD,DDR,,,,,,deleted,
+Gilbert and Ellice Islands,GE,GEL,,,,,,deleted,268
+Johnston Island,JT,JTN,,,,,,deleted,
+Midway Islands,MI,MID,,,,,,deleted,
+Netherlands Antilles,AN,ANT,,,,,,deleted,
+Neutral Zone,NT,NTZ,,,,,,deleted,
+New Hebrides,NH,NHB,,,,,,deleted,
+"Pacific Islands, Trust Territory of the",PC,PCI,,,,,,deleted,
+Panama Canal Zone,PZ,PCZ,,,,,,deleted,
+Serbia and Montenegro,CS,SCG,,,,,,deleted,
+Sikkim,SK,SKM,,,,,,deleted,703
+Southern Rhodesia,RH,RHO,,,,,,deleted,
+U.S. Miscellaneous Pacific Islands,PU,PUS,,,,,,deleted,
+Upper Volta,HV,HVO,,,,,,deleted,
+"Viet-Nam, Democratic Republic of",VD,VDR,,,,,,deleted,
+Wake Island,WK,WAK,,,,,,deleted,
+"Yemen, Democratic",YD,YMD,,,,,,deleted,
+Yugoslavia,YU,YUG,,,,,,deleted,
+Zaire,ZR,ZAR,,,,,,deleted,

--- a/index.js
+++ b/index.js
@@ -28,6 +28,11 @@ _.each(countriesAll, function (country) {
   if (!exportedAlpha3 || exportedAlpha3.status === 'deleted') {
     exports.countries[country.alpha3] = country;
   }
+
+  var exportedNumeric = exports.countries[country.numeric];
+  if (!exportedNumeric || exportedNumeric.status === 'deleted') {
+    exports.countries[country.numeric] = country;
+  }
 });
 
 exports.currencies = {

--- a/test/countries.js
+++ b/test/countries.js
@@ -32,16 +32,27 @@ describe('countries', function () {
     });
   });
 
+  describe('numeric', function () {
+    it('should find France', function () {
+      assert.equal( countries['250'].name, 'France');
+      assert.deepEqual( countries['250'].currencies, ['EUR']);
+    });
+  });
+
   describe('check each country has correct form', function () {
     _.each( countries.all, function (country) {
       describe(country.name, function () {
         it('should have a status', function () {
           assert( country.status );
         });
-        it('should have correctly formed alpha2 and alpha3', function () {
+        it('should have correctly formed alpha2, alpha3 and numeric', function () {
           assert(country.alpha2.match(/^[A-Z]{2}$/), 'alpha2 correctly formed - ' + country.alpha2);
           if (country.alpha3.length) {
             assert(country.alpha3.match(/^[A-Z]{3}$/), 'alpha3 correctly formed - ' + country.alpha3);
+          }
+
+          if (country.numeric.length) {
+            assert(country.numeric.match(/^\d{3}$/), 'numeric correctly formed - ' + country.numeric);
           }
         });
       });


### PR DESCRIPTION
This PR adds numeric country codes where available. The codes were added with a simple Python script using data from the [`pycountry`](https://pypi.python.org/pypi/pycountry) package.