### PR TITLE
Add assigned to export.countries

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,12 @@ exports.countries = {
   all: countriesAll,
 };
 
+var assignedCountries = []
 _.each(countriesAll, function (country) {
+  if (country.status === 'assigned') {
+    assignedCountries.push(country)
+  }
+
   // prefer assigned country codes over inactive ones
   var exportedAlpha2 = exports.countries[country.alpha2];
   if (!exportedAlpha2 || exportedAlpha2.status === 'deleted') {
@@ -29,6 +34,8 @@ _.each(countriesAll, function (country) {
     exports.countries[country.alpha3] = country;
   }
 });
+
+exports.countries['assigned'] = assignedCountries
 
 exports.currencies = {
   all: currenciesAll,

--- a/test/countries.js
+++ b/test/countries.js
@@ -14,6 +14,21 @@ describe('countries', function () {
     });
   });
 
+  describe('assigned', function () {
+    it('should only contain assigned countries', function () {
+      assert( _.isArray(countries.assigned) );
+      assert(countries.assigned.length < countries.all.length);
+
+      var exceptionalReservation = countries.SU
+      var deletedCode = countries.YD
+      var transitionalReservation = countries.BU
+
+      assert(countries.assigned.indexOf(exceptionalReservation) === -1)
+      assert(countries.assigned.indexOf(deletedCode) === -1)
+      assert(countries.assigned.indexOf(transitionalReservation) === -1)
+    });
+  });
+
   describe('alpha2', function () {
     it('should find USA', function () {
       assert.equal( countries.BE.name, 'Belgium');


### PR DESCRIPTION
This is so you can get a list of current countries without having to
filter everything yourself.

Particularly useful if you want a country picker for something that
needs current countries, like an address form.