### PR TITLE
Use correct currency code

### DIFF
--- a/data/countries.csv
+++ b/data/countries.csv
@@ -19,7 +19,7 @@ Bahamas,BS,BHS,,+1 242,BSD,🇧🇸,BAH,eng,assigned
 Bahrain,BH,BHR,,+973,BHD,🇧🇭,BRN,ara,assigned
 Bangladesh,BD,BGD,,+880,BDT,🇧🇩,BAN,ben,assigned
 Barbados,BB,BRB,,+1 246,BBD,🇧🇧,BAR,eng,assigned
-Belarus,BY,BLR,,+375,BYR,🇧🇾,BLR,"bel,rus",assigned
+Belarus,BY,BLR,,+375,BYN,🇧🇾,BLR,"bel,rus",assigned
 Belgium,BE,BEL,,+32,EUR,🇧🇪,BEL,"nld,fra,deu",assigned
 Belize,BZ,BLZ,,+501,BZD,🇧🇿,BIZ,eng,assigned
 Benin,BJ,BEN,,+229,XOF,🇧🇯,BEN,fra,assigned

--- a/data/countries.json
+++ b/data/countries.json
@@ -662,7 +662,7 @@
       "+375"
     ],
     "currencies": [
-      "BYR"
+      "BYN"
     ],
     "emoji": "🇧🇾",
     "ioc": "BLR",

--- a/data/currencies.csv
+++ b/data/currencies.csv
@@ -23,7 +23,7 @@ BRL,2,Brazilian real,986
 BSD,2,Bahamian dollar,44
 BTN,2,Bhutanese ngultrum,64
 BWP,2,Botswana pula,72
-BYR,0,Belarusian ruble,974
+BYN,0,Belarusian ruble,974
 BZD,2,Belize dollar,84
 CAD,2,Canadian dollar,124
 CDF,2,Congolese franc,976

--- a/data/currencies.json
+++ b/data/currencies.json
@@ -144,7 +144,7 @@
     "number": "72"
   },
   {
-    "code": "BYR",
+    "code": "BYN",
     "decimals": 0,
     "name": "Belarusian ruble",
     "number": "974"


### PR DESCRIPTION
According to http://en.wikipedia.org/wiki/ISO_4217 which is linked in the readme the code for the Belarusian was replaced from BYR to BYN - this PR updates it