### PR TITLE
Fixes typo in `Central Africa` name

### DIFF
--- a/data/regions.js
+++ b/data/regions.js
@@ -90,7 +90,7 @@ regions.westernAsia = {
 }
 
 regions.centralAfrica = {
-  name: 'Central Aftrica',
+  name: 'Central Africa',
   countries: [
     // source is http://en.wikipedia.org/wiki/Central_Africa
     'AO', // Angola


### PR DESCRIPTION
I noticed a typo in the Region data for Central Africa.